### PR TITLE
Redraw cursors on layout change

### DIFF
--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -19,7 +19,6 @@ interface RTCOverlayProps {
  */
 export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
 	const overlayRef = useRef< HTMLDivElement >( null );
-	const renderCursorsRef = useRef< () => void >();
 
 	const { isAvatarsEnabled, isDebugToolsEnabled } = useSelect<
 		SettingsStoreSelectors,
@@ -31,6 +30,8 @@ export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
 		};
 	} );
 
+	const renderCursorsRef = useRenderCursors( overlayRef, iframeDocument );
+
 	// Detect layout changes on overlay (e.g. turning on "Show Template") and window
 	// resizes, and re-render the cursors.
 	const resizeObserverRef = useResizeObserver( () => {
@@ -41,7 +42,6 @@ export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
 	const mergedRef = useMergeRefs( [ overlayRef, resizeObserverRef ] );
 
 	useBlockHighlighting( iframeDocument );
-	useRenderCursors( overlayRef, renderCursorsRef, iframeDocument );
 
 	return (
 		<>

--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -1,3 +1,4 @@
+import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 
@@ -29,6 +30,17 @@ export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
 		};
 	} );
 
+	// Detect layout changes on overlay (e.g. turning on "Show Template")
+	// and fire an event that components inside of the overlay can listen to.
+	const resizeObserverRef = useResizeObserver( () => {
+		if ( overlayRef.current ) {
+			overlayRef.current.dispatchEvent( new CustomEvent( 'redrawCursors' ) );
+		}
+	} );
+
+	// Merge the refs to use the same element for both overlay and resize observation
+	const mergedRef = useMergeRefs( [ overlayRef, resizeObserverRef ] );
+
 	useBlockHighlighting( iframeDocument );
 	useRenderCursors( overlayRef, iframeDocument );
 
@@ -36,7 +48,7 @@ export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
 		<>
 			{ /* This is a full overlay that covers the entire iframe document.
 				Good for scrollable elements like cursor indicators */ }
-			<div className="vip-real-time-collaboration-overlay-full" ref={ overlayRef } />
+			<div className="vip-real-time-collaboration-overlay-full" ref={ mergedRef } />
 
 			{ /* This is a fixed overlay that covers the iframe window.
 				Good for floating elements like awareness avatars */ }

--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -31,8 +31,8 @@ export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
 		};
 	} );
 
-	// Detect layout changes on overlay (e.g. turning on "Show Template")
-	// and fire an event that components inside of the overlay can listen to.
+	// Detect layout changes on overlay (e.g. turning on "Show Template") and window
+	// resizes, and re-render the cursors.
 	const resizeObserverRef = useResizeObserver( () => {
 		renderCursorsRef.current?.();
 	} );

--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -18,7 +18,8 @@ interface RTCOverlayProps {
  * This component is responsible for rendering awareness components within the editor iframe.
  */
 export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
-	const overlayRef = useRef< HTMLDivElement | null >( null );
+	const overlayRef = useRef< HTMLDivElement >( null );
+	const renderCursorsRef = useRef< () => void >();
 
 	const { isAvatarsEnabled, isDebugToolsEnabled } = useSelect<
 		SettingsStoreSelectors,
@@ -33,16 +34,14 @@ export function RTCOverlay( { iframeDocument }: RTCOverlayProps ) {
 	// Detect layout changes on overlay (e.g. turning on "Show Template")
 	// and fire an event that components inside of the overlay can listen to.
 	const resizeObserverRef = useResizeObserver( () => {
-		if ( overlayRef.current ) {
-			overlayRef.current.dispatchEvent( new CustomEvent( 'redrawCursors' ) );
-		}
+		renderCursorsRef.current?.();
 	} );
 
 	// Merge the refs to use the same element for both overlay and resize observation
 	const mergedRef = useMergeRefs( [ overlayRef, resizeObserverRef ] );
 
 	useBlockHighlighting( iframeDocument );
-	useRenderCursors( overlayRef, iframeDocument );
+	useRenderCursors( overlayRef, renderCursorsRef, iframeDocument );
 
 	return (
 		<>

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -78,6 +78,24 @@ export function useRenderCursors(
 			window.removeEventListener( 'resize', throttledHandleResize );
 		};
 	}, [] );
+
+	// Listen for layout changes from ResizeObserver
+	useEffect( () => {
+		const overlay = overlayRef.current;
+		if ( ! overlay ) {
+			return;
+		}
+
+		const handleRedrawCursors = () => {
+			// ResizeObserver detected a layout change - redraw cursors
+			if ( renderCursorsRef.current ) {
+				renderCursorsRef.current();
+			}
+		};
+
+		overlay.addEventListener( 'redrawCursors', handleRedrawCursors );
+		return () => overlay.removeEventListener( 'redrawCursors', handleRedrawCursors );
+	}, [ overlayRef.current ] );
 }
 
 /**

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -1,5 +1,5 @@
 import { useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 import { useSortedAwarenessUsers } from '@/hooks/use-sorted-awareness-users';
 import { store as rtcSettingsStore, SettingsStoreSelectors } from '@/store/settings-store';
@@ -20,13 +20,14 @@ const logger = new Logger( 'use-render-cursors' );
  * Custom hook for rendering cursors for each user in the editor.
  * @param overlayRef - The ref to the overlay element
  * @param blockEditorDocument - The block editor document
- * @param awareness - The awareness instance
+ * @returns A ref to the render function. Can be used by parent to trigger a re-render.
  */
 export function useRenderCursors(
 	overlayRef: MutableRefObject< HTMLElement | null >,
-	renderCursorsRef: MutableRefObject< ( () => void ) | undefined >,
 	blockEditorDocument: Document | null
 ) {
+	const renderCursorsRef = useRef< () => void >();
+
 	const drawType = useSelect< SettingsStoreSelectors, DrawType >( select => {
 		const { isAwarenessCursorsEnabled, isSelfAwarenessEnabled } = select( rtcSettingsStore );
 		if ( isAwarenessCursorsEnabled() ) {
@@ -59,6 +60,8 @@ export function useRenderCursors(
 		// Render cursors immediately when data changes
 		renderCursorsRef.current();
 	}, [ drawType, sortedUsers, overlayRef.current, blockEditorDocument ] );
+
+	return renderCursorsRef;
 }
 
 /**

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -1,11 +1,10 @@
 import { useSelect } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 import { useSortedAwarenessUsers } from '@/hooks/use-sorted-awareness-users';
 import { store as rtcSettingsStore, SettingsStoreSelectors } from '@/store/settings-store';
 import { Logger } from '@/utilities/logger';
 import { type SelectionCursor, type SelectionState, SelectionType } from '@/utilities/selection';
-import { throttleByAnimationFrame } from '@/utilities/throttle';
 
 import type { MutableRefObject } from 'react';
 
@@ -24,7 +23,8 @@ const logger = new Logger( 'use-render-cursors' );
  * @param awareness - The awareness instance
  */
 export function useRenderCursors(
-	overlayRef: MutableRefObject< HTMLElement | null >,
+	overlayRef: MutableRefObject< HTMLElement >,
+	renderCursorsRef: MutableRefObject< ( () => void ) | undefined >,
 	blockEditorDocument: Document | null
 ) {
 	const drawType = useSelect< SettingsStoreSelectors, DrawType >( select => {
@@ -41,9 +41,6 @@ export function useRenderCursors(
 	} );
 
 	const sortedUsers = useSortedAwarenessUsers();
-
-	// Use a ref to store the current render function to avoid stale closures
-	const renderCursorsRef = useRef< () => void >();
 
 	// Draw user cursors in the overlay.
 	useEffect( () => {
@@ -62,40 +59,6 @@ export function useRenderCursors(
 		// Render cursors immediately when data changes
 		renderCursorsRef.current();
 	}, [ drawType, sortedUsers, overlayRef.current, blockEditorDocument ] );
-
-	// Also re-render cursors on resize
-	useEffect( () => {
-		const handleResize = () => {
-			if ( renderCursorsRef.current ) {
-				renderCursorsRef.current();
-			}
-		};
-
-		const throttledHandleResize = throttleByAnimationFrame( handleResize );
-
-		window.addEventListener( 'resize', throttledHandleResize );
-		return () => {
-			window.removeEventListener( 'resize', throttledHandleResize );
-		};
-	}, [] );
-
-	// Listen for layout changes from ResizeObserver
-	useEffect( () => {
-		const overlay = overlayRef.current;
-		if ( ! overlay ) {
-			return;
-		}
-
-		const handleRedrawCursors = () => {
-			// ResizeObserver detected a layout change - redraw cursors
-			if ( renderCursorsRef.current ) {
-				renderCursorsRef.current();
-			}
-		};
-
-		overlay.addEventListener( 'redrawCursors', handleRedrawCursors );
-		return () => overlay.removeEventListener( 'redrawCursors', handleRedrawCursors );
-	}, [ overlayRef.current ] );
 }
 
 /**

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -23,7 +23,7 @@ const logger = new Logger( 'use-render-cursors' );
  * @param awareness - The awareness instance
  */
 export function useRenderCursors(
-	overlayRef: MutableRefObject< HTMLElement >,
+	overlayRef: MutableRefObject< HTMLElement | null >,
 	renderCursorsRef: MutableRefObject< ( () => void ) | undefined >,
 	blockEditorDocument: Document | null
 ) {


### PR DESCRIPTION
Modify `<RTCOverlay>` and `useRenderCursors()` to listen for element resize events, and redraw cursors. Along with https://github.com/Automattic/gutenberg/pull/26, this fixes cursor drawing when the "Show Template" option is enabled.

Previously, we only listened for window resize events, but this didn't trigger when "Show Template" was enabled.

I also experimented with listening for [`getRenderingMode()`](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-editor/#getrenderingmode) state changes from the core editor store, but layout can change afterward as loadable resources like images pop in. Listening for element resizes directly allows cursors to redraw to the correct location as the template loads.