### PR TITLE
Fix revision functionality

### DIFF
--- a/inc/Compatibility/Compatibility.php
+++ b/inc/Compatibility/Compatibility.php
@@ -72,8 +72,7 @@ final class Compatibility {
 	/**
 	 * Check if the Gutenberg plugin is active.
 	 *
-	 * TODO: Check GUTENBERG_VERSION in production to ensure it is running a
-	 * compatible version.
+	 * TODO: Check GUTENBERG_VERSION in production to ensure it is running a compatible version.
 	 */
 	private static function is_gutenberg_plugin_active(): bool {
 		return defined( 'IS_GUTENBERG_PLUGIN' ) && constant( 'IS_GUTENBERG_PLUGIN' );

--- a/inc/Editor/CrdtPersistence.php
+++ b/inc/Editor/CrdtPersistence.php
@@ -6,6 +6,12 @@ use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use function add_action;
 use function post_type_supports;
 use function register_meta;
+use function get_post;
+use function get_post_meta;
+
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
 
 defined( 'ABSPATH' ) || exit();
 
@@ -18,6 +24,7 @@ final class CrdtPersistence {
 
 	public function __construct() {
 		add_action( 'init', [ $this, 'register_meta' ], 999, 0 );
+		add_action( 'wp_restore_post_revision', [ $this, 'revision_restored' ], 10, 2 );
 	}
 
 	public function register_meta(): void {
@@ -36,6 +43,26 @@ final class CrdtPersistence {
 					'type' => 'string',
 				]
 			);
+		}
+	}
+
+	public function revision_restored( int $post_id, int $revision_id ): void {
+		// issue an update to the post meta to trigger sync
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		$crdt_meta = get_post_meta( $post_id, self::POST_META_KEY, true );
+		if ( is_string( $crdt_meta ) && ! empty( $crdt_meta ) ) {
+			$crdt_meta_array = json_decode( $crdt_meta, true );
+			if ( json_last_error() === JSON_ERROR_NONE ) {
+				$crdt_meta_array['isRevision'] = true;
+				$encoded_meta = json_encode( $crdt_meta_array );
+				if ( $encoded_meta !== false ) {
+					update_post_meta( $post_id, self::POST_META_KEY, $encoded_meta );
+				}
+			}
 		}
 	}
 }

--- a/inc/Editor/CrdtPersistence.php
+++ b/inc/Editor/CrdtPersistence.php
@@ -24,7 +24,6 @@ final class CrdtPersistence {
 
 	public function __construct() {
 		add_action( 'init', [ $this, 'register_meta' ], 999, 0 );
-		add_action( 'wp_restore_post_revision', [ $this, 'revision_restored' ], 10, 2 );
 	}
 
 	public function register_meta(): void {
@@ -43,26 +42,6 @@ final class CrdtPersistence {
 					'type' => 'string',
 				]
 			);
-		}
-	}
-
-	public function revision_restored( int $post_id, int $revision_id ): void {
-		// issue an update to the post meta to trigger sync
-		$post = get_post( $post_id );
-		if ( ! $post instanceof WP_Post ) {
-			return;
-		}
-
-		$crdt_meta = get_post_meta( $post_id, self::POST_META_KEY, true );
-		if ( is_string( $crdt_meta ) && ! empty( $crdt_meta ) ) {
-			$crdt_meta_array = json_decode( $crdt_meta, true );
-			if ( json_last_error() === JSON_ERROR_NONE ) {
-				$crdt_meta_array['isRevision'] = true;
-				$encoded_meta = json_encode( $crdt_meta_array );
-				if ( $encoded_meta !== false ) {
-					update_post_meta( $post_id, self::POST_META_KEY, $encoded_meta );
-				}
-			}
 		}
 	}
 }

--- a/inc/Editor/CrdtPersistence.php
+++ b/inc/Editor/CrdtPersistence.php
@@ -7,7 +7,6 @@ use function add_action;
 use function post_type_supports;
 use function register_meta;
 
-
 defined( 'ABSPATH' ) || exit();
 
 /**

--- a/inc/Editor/CrdtPersistence.php
+++ b/inc/Editor/CrdtPersistence.php
@@ -6,12 +6,7 @@ use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use function add_action;
 use function post_type_supports;
 use function register_meta;
-use function get_post;
-use function get_post_meta;
 
-use WP_Post;
-use WP_REST_Request;
-use WP_REST_Response;
 
 defined( 'ABSPATH' ) || exit();
 

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -47,13 +47,14 @@ final class Overrides {
 	 */
 	public function filter_post_meta( mixed $value, int $object_id, string $meta_key ): mixed {
 		global $post, $pagenow;
-
 		$supported_post_types = Compatibility::get_supported_post_types();
-		if ( ! $post || $post->ID !== $object_id || '_edit_lock' !== $meta_key || 'revision.php' !== $pagenow || ! in_array( $post->post_type, $supported_post_types, true ) ) {
-			return $value;
+
+		// If it's the revisions page, the meta key is the edit_lock and we have the post then we want to give back false.
+		// This is to avoid the issue where the revision screen shows the post as locked for collaborators.
+		if ( $post && $post->ID === $object_id && '_edit_lock' === $meta_key && 'revision.php' === $pagenow && in_array( $post->post_type, $supported_post_types, true ) ) {
+			return false;
 		}
 
-		// If it's the revisions page, the meta key is the edit_lock and we have the post then this is good to go.
-		return false;
+		return $value;
 	}
 }

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -24,6 +24,9 @@ final class Overrides {
 
 		// Force the removal of refreshing the post lock, runs on admin_init as that is after the filter is set.
 		add_action( 'admin_init', [ $this, 'remove_heartbeat_post_lock' ] );
+
+		// Ensure that the _edit_lock meta key is never returned, effectively disabling the post lock functionality.
+		add_filter( 'get_post_metadata', [ $this, 'filter_post_meta' ], 10, 3 );
 	}
 
 	/**
@@ -31,5 +34,28 @@ final class Overrides {
 	 */
 	public function remove_heartbeat_post_lock(): void {
 		remove_filter( 'heartbeat_received', 'wp_refresh_post_lock' );
+	}
+
+	/**
+	 * Set the _edit_lock meta key to false, to disable post locking.
+	 *
+	 * @param mixed $value the current meta value.
+	 * @param int   $object_id the object ID.
+	 * @param string $meta_key the meta key.
+	 * @return mixed the filtered meta value.
+	 */
+	public function filter_post_meta( $value, $object_id, $meta_key ) {
+		// get the post using the object_id
+		$post = get_post( $object_id );
+
+		if ( ! $post instanceof \WP_Post ) {
+			return $value;
+		}
+
+		if ( '_edit_lock' === $meta_key ) {
+			return false;
+		}
+
+		return $value;
 	}
 }

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -4,9 +4,11 @@ namespace VIPRealTimeCollaboration\Overrides;
 
 defined( 'ABSPATH' ) || exit();
 
+use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use function add_action;
 use function add_filter;
 use function remove_filter;
+use function get_post;
 
 /**
  * Class to handle overrides for the Block Editor functionality.
@@ -44,18 +46,27 @@ final class Overrides {
 	 * @param string $meta_key the meta key.
 	 * @return mixed the filtered meta value.
 	 */
-	public function filter_post_meta( $value, $object_id, $meta_key ) {
+	public function filter_post_meta( mixed $value, int $object_id, string $meta_key ): mixed {
 		// get the post using the object_id
 		$post = get_post( $object_id );
 
+		// Ensure that the post is a valid WP_Post object, and it exists.
 		if ( ! $post instanceof \WP_Post ) {
 			return $value;
 		}
 
+		// Ensure collaboration is enabled for this post type.
+		$supported_post_types = Compatibility::get_supported_post_types();
+		if ( ! in_array( $post->post_type, $supported_post_types, true ) ) {
+			return $value;
+		}
+
+		// If the meta key is _edit_lock, return false to disable the lock.
 		if ( '_edit_lock' === $meta_key ) {
 			return false;
 		}
 
+		// For all other meta keys, return the original value.
 		return $value;
 	}
 }

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -9,6 +9,8 @@ use function add_action;
 use function add_filter;
 use function remove_filter;
 
+use WP_Post;
+
 /**
  * Class to handle overrides for the Block Editor functionality.
  *
@@ -38,20 +40,25 @@ final class Overrides {
 	}
 
 	/**
-	 * Set the _edit_lock meta key to false, to disable post locking.
+	 * Set the _edit_lock meta key to false, to disable post locking on revisions.php only.
 	 *
 	 * @param mixed $value the current meta value.
 	 * @param int   $object_id the object ID.
 	 * @param string $meta_key the meta key.
 	 * @return mixed the filtered meta value.
+	 * @psalm-suppress PossiblyUnusedReturnValue
 	 */
 	public function filter_post_meta( mixed $value, int $object_id, string $meta_key ): mixed {
 		global $post, $pagenow;
+
+		if ( 'revision.php' !== $pagenow || '_edit_lock' !== $meta_key ) {
+			return $value;
+		}
+
 		$supported_post_types = Compatibility::get_supported_post_types();
 
-		// If it's the revisions page, the meta key is the edit_lock and we have the post then we want to give back false.
-		// This is to avoid the issue where the revision screen shows the post as locked for collaborators.
-		if ( $post && $post->ID === $object_id && '_edit_lock' === $meta_key && 'revision.php' === $pagenow && in_array( $post->post_type, $supported_post_types, true ) ) {
+		/** @var WP_Post|null $post */
+		if ( $post && $post->ID === $object_id && in_array( $post->post_type, $supported_post_types, true ) ) {
 			return false;
 		}
 

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -8,7 +8,6 @@ use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use function add_action;
 use function add_filter;
 use function remove_filter;
-use function get_post;
 
 /**
  * Class to handle overrides for the Block Editor functionality.
@@ -47,26 +46,14 @@ final class Overrides {
 	 * @return mixed the filtered meta value.
 	 */
 	public function filter_post_meta( mixed $value, int $object_id, string $meta_key ): mixed {
-		// get the post using the object_id
-		$post = get_post( $object_id );
+		global $post, $pagenow;
 
-		// Ensure that the post is a valid WP_Post object, and it exists.
-		if ( ! $post instanceof \WP_Post ) {
-			return $value;
-		}
-
-		// Ensure collaboration is enabled for this post type.
 		$supported_post_types = Compatibility::get_supported_post_types();
-		if ( ! in_array( $post->post_type, $supported_post_types, true ) ) {
+		if ( ! $post || $post->ID !== $object_id || '_edit_lock' !== $meta_key || 'revision.php' !== $pagenow || ! in_array( $post->post_type, $supported_post_types, true ) ) {
 			return $value;
 		}
 
-		// If the meta key is _edit_lock, return false to disable the lock.
-		if ( '_edit_lock' === $meta_key ) {
-			return false;
-		}
-
-		// For all other meta keys, return the original value.
-		return $value;
+		// If it's the revisions page, the meta key is the edit_lock and we have the post then this is good to go.
+		return false;
 	}
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { WebsocketProvider } from 'y-websocket';
+
+/**
  * Internal dependencies
  */
 import { AwarenessManager } from '@/awareness-manager';
@@ -8,13 +13,18 @@ import {
 	getPersistedCrdtDocFromEntityMeta,
 	type EntityMetaRecord,
 } from '@/utilities/crdt';
-import { getHashForEntityRecord, getMetaFromEntityRecord } from '@/utilities/entity';
+import {
+	getHashForEntityRecord,
+	getMetaFromEntityRecord,
+	updateEntityFromRevisionIfRestored,
+} from '@/utilities/entity';
 import { Logger } from '@/utilities/logger';
 import { createWebSocketConnection, type WebSocketConnectionConfig } from '@/websocket-client';
 
+/**
+ * WordPress dependencies
+ */
 import type { CRDTDoc, ObjectData, RecordHandlers, SyncConfig } from '@wordpress/sync';
-import type { WebsocketProvider } from 'y-websocket';
-
 import { store as editorStore } from '@wordpress/editor';
 import { select } from '@wordpress/data';
 
@@ -121,6 +131,14 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 		} );
 
 		return Promise.resolve( persistedDoc );
+	}
+
+	protected async overrideInitialRemoteUpdates(
+		syncConfig: SyncConfig,
+		record: ObjectData,
+		initialYDoc: CRDTDoc
+	): Promise< void > {
+		updateEntityFromRevisionIfRestored( record, initialYDoc, syncConfig );
 	}
 
 	private onProviderStatusChange(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -15,6 +15,9 @@ import { createWebSocketConnection, type WebSocketConnectionConfig } from '@/web
 import type { CRDTDoc, ObjectData, RecordHandlers, SyncConfig } from '@wordpress/sync';
 import type { WebsocketProvider } from 'y-websocket';
 
+import { store as coreStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
+
 export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 	private logger: Logger = new Logger( 'provider' );
 
@@ -95,6 +98,13 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 			return Promise.resolve( null );
 		}
 
+		// try {
+		// 	const editedRecord = select( coreStore ).getEditedEntityRecord( 'postType', 'post', record.id as number );
+		// 	this.logger.debug( 'Fetched edited entity record', { editedRecord } );
+		// } catch ( error ) {
+		// 	this.logger.error( 'Error getting edited entity record', { error } );
+		// }
+
 		const entityMeta = getMetaFromEntityRecord( record );
 
 		// Attempt to load the initial CRDT document from post meta.
@@ -104,6 +114,13 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 			expectedHash,
 			expectedVersion
 		);
+
+		// if ( ! persistedDoc ) {
+		// 	console.log( record.content );
+		// } else {
+		// 	const ymap = persistedDoc.getMap( 'document' );
+		// 	console.debug( 'Loaded persisted CRDT doc', ymap.toJSON() );
+		// }
 
 		const logMessage = persistedDoc
 			? 'Found persisted CRDT doc in entity meta'

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -15,7 +15,7 @@ import { createWebSocketConnection, type WebSocketConnectionConfig } from '@/web
 import type { CRDTDoc, ObjectData, RecordHandlers, SyncConfig } from '@wordpress/sync';
 import type { WebsocketProvider } from 'y-websocket';
 
-import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 import { select } from '@wordpress/data';
 
 export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
@@ -77,7 +77,10 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 			{ ...record, ...changes },
 			syncConfig.syncedProperties
 		);
-		const entityMeta = createPersistedCrdtDocMetaRecord( ydoc, contentHash );
+
+		const lastRevisionId = select( editorStore ).getCurrentPostLastRevisionId() ?? 0;
+
+		const entityMeta = createPersistedCrdtDocMetaRecord( ydoc, contentHash, lastRevisionId );
 
 		this.logger.debug( 'Providing updated entity meta to saveEntityRecord', {
 			objectType,
@@ -101,13 +104,6 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 			return Promise.resolve( null );
 		}
 
-		// try {
-		// 	const editedRecord = select( coreStore ).getEditedEntityRecord( 'postType', 'post', record.id as number );
-		// 	this.logger.debug( 'Fetched edited entity record', { editedRecord } );
-		// } catch ( error ) {
-		// 	this.logger.error( 'Error getting edited entity record', { error } );
-		// }
-
 		const entityMeta = getMetaFromEntityRecord( record );
 
 		// Attempt to load the initial CRDT document from post meta.
@@ -117,13 +113,6 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 			expectedHash,
 			expectedVersion
 		);
-
-		// if ( ! persistedDoc ) {
-		// 	console.log( record.content );
-		// } else {
-		// 	const ymap = persistedDoc.getMap( 'document' );
-		// 	console.debug( 'Loaded persisted CRDT doc', ymap.toJSON() );
-		// }
 
 		const logMessage = persistedDoc
 			? 'Found persisted CRDT doc in entity meta'

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,6 +17,7 @@ import {
 	getHashForEntityRecord,
 	getMetaFromEntityRecord,
 	updateEntityFromRevisionIfRestored,
+	getLastRevisionIDFromEntityRecord,
 } from '@/utilities/entity';
 import { Logger } from '@/utilities/logger';
 import { createWebSocketConnection, type WebSocketConnectionConfig } from '@/websocket-client';
@@ -27,6 +28,7 @@ import { createWebSocketConnection, type WebSocketConnectionConfig } from '@/web
 import type { CRDTDoc, ObjectData, RecordHandlers, SyncConfig } from '@wordpress/sync';
 import { store as editorStore } from '@wordpress/editor';
 import { select } from '@wordpress/data';
+import { PERSISTED_STATE_POST_META_KEY } from './utilities/config';
 
 export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 	private logger: Logger = new Logger( 'provider' );
@@ -67,7 +69,7 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 	public async createEntityMeta(
 		syncConfig: SyncConfig,
 		record: ObjectData,
-		changes: Partial< ObjectData >
+		changes: Partial< ObjectData > = {}
 	): Promise< EntityMetaRecord > {
 		if ( ! syncConfig.supports?.crdtPersistence ) {
 			return {};
@@ -86,7 +88,11 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 			syncConfig.syncedProperties
 		);
 
-		const lastRevisionId = select( editorStore ).getCurrentPostLastRevisionId() ?? 0;
+		let lastRevisionId = getLastRevisionIDFromEntityRecord( record );
+
+		if ( ! lastRevisionId ) {
+			lastRevisionId = select( editorStore ).getCurrentPostLastRevisionId() ?? 0;
+		}
 
 		const entityMeta = createPersistedCrdtDocMetaRecord( ydoc, contentHash, lastRevisionId );
 
@@ -138,7 +144,26 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 		record: ObjectData,
 		initialYDoc: CRDTDoc
 	): Promise< void > {
-		updateEntityFromRevisionIfRestored( record, initialYDoc, syncConfig );
+		const isDocUpdated = updateEntityFromRevisionIfRestored( record, initialYDoc, syncConfig );
+
+		// Update the lastRevisionId in the meta if we restored from a revision.
+		// This prevents multiple restorations if the user saves without making any changes.
+		// The meta will be updated on the next save.
+		if ( isDocUpdated ) {
+			this.logger.debug( 'Updating meta after restoring from revision' );
+
+			const updatedEntityMeta = await this.createEntityMeta( syncConfig, record );
+
+			// Ensure we skip the update if there is no meta available.
+			if ( Object.keys( updatedEntityMeta ).length > 0 ) {
+				// This is to stop the typescript errors that come up with the record.meta not being defined potentially.
+				record.meta = { ...( record.meta ?? {} ), ...updatedEntityMeta };
+
+				this.logger.debug( 'Updated record meta after restoring from revision', {
+					recordMeta: record.meta,
+				} );
+			}
+		}
 	}
 
 	private onProviderStatusChange(

--- a/src/utilities/crdt.ts
+++ b/src/utilities/crdt.ts
@@ -260,7 +260,7 @@ export function getRawCRDTDocMetaValue(
 		// eslint-disable-next-line security/detect-object-injection
 		const rawMetaValue: unknown = entityMeta[ PERSISTED_STATE_POST_META_KEY ] ?? null;
 
-		if ( 'string' !== typeof rawMetaValue || rawMetaValue === '' ) {
+		if ( 'string' !== typeof rawMetaValue ) {
 			return null;
 		}
 

--- a/src/utilities/crdt.ts
+++ b/src/utilities/crdt.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { type CRDTDoc } from '@wordpress/sync';
 import * as buffer from 'lib0/buffer';
 import * as Y from 'yjs';
 
@@ -10,6 +9,25 @@ import * as Y from 'yjs';
  */
 import { isDevelopment, PERSISTED_STATE_POST_META_KEY } from '@/utilities/config';
 import { Logger } from '@/utilities/logger';
+
+/**
+ * WordPress dependencies
+ */
+
+import { type CRDTDoc, type SyncConfig } from '@wordpress/sync';
+
+type YBlock = Y.Map<
+	/* name, clientId, and originalContent are strings. */
+	| string
+	/* validationIssues? is an array of strings. */
+	| string[]
+	/* attributes is a Y.Map< unknown >. */
+	| YBlockAttributes
+	/* innerBlocks is a Y.Array< YBlock >. */
+	| Y.Array< YBlock >
+>;
+
+type YBlockAttributes = Y.Map< Y.Text | unknown >;
 
 export interface EntityMetaRecord {
 	string?: string; // serialized PersistedCrdtDocMetaValue
@@ -49,28 +67,55 @@ function deserializeCrdtDoc( serializedCrdtDoc: string, version = 0 ): CRDTDoc {
 
 /**
  * Type predicate to check the deserialized entity meta value shape. This does
- * not validate the CRDT document itself, but it does validate the content hash
- * and document version.
+ * not validate the CRDT document itself or the contents of the entity meta value.
+ * That's done by isValidCrdtDocMetaContent().
  */
-function isValidCrdtDocMetaValueShape(
-	metaValue: unknown,
-	expectedContentHash: string,
-	expectedVersion: number
-): metaValue is PersistedCrdtDocMetaValue {
+function isValidCrdtDocMetaShape( metaValue: unknown ): metaValue is PersistedCrdtDocMetaValue {
 	if ( 'object' !== typeof metaValue || null === metaValue ) {
 		logger.debug( 'Persisted CRDT document was not found', { metaValue } );
 		return false;
 	}
 
-	if ( ! ( 'contentHash' in metaValue && 'crdtDoc' in metaValue && 'version' in metaValue ) ) {
+	if (
+		! (
+			'contentHash' in metaValue &&
+			'crdtDoc' in metaValue &&
+			'version' in metaValue &&
+			'lastRevisionId' in metaValue
+		)
+	) {
 		logger.error( 'Persisted CRDT document is missing expected properties', { metaValue } );
 		return false;
 	}
 
 	if (
 		'string' !== typeof metaValue.contentHash ||
-		metaValue.contentHash !== expectedContentHash
+		'string' !== typeof metaValue.crdtDoc ||
+		'number' !== typeof metaValue.version ||
+		'number' !== typeof metaValue.lastRevisionId
 	) {
+		logger.error( 'Persisted CRDT document has invalid property types', { metaValue } );
+		return false;
+	}
+
+	if ( ! metaValue.crdtDoc ) {
+		logger.error( 'Persisted CRDT document is empty', { metaValue } );
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * This validates the contents of the deserialized entity meta value shape. That
+ * includes validating the content hash and document version.
+ */
+function isValidCrdtDocMetaContent(
+	metaValue: PersistedCrdtDocMetaValue,
+	expectedContentHash: string,
+	expectedVersion: number
+): boolean {
+	if ( metaValue.contentHash !== expectedContentHash ) {
 		logger.warn( 'Persisted CRDT document content hash mismatch', {
 			expectedContentHash,
 			metaValue,
@@ -78,15 +123,10 @@ function isValidCrdtDocMetaValueShape(
 		return false;
 	}
 
-	if ( 'string' !== typeof metaValue.crdtDoc || ! metaValue.crdtDoc ) {
-		logger.error( 'Persisted CRDT document is empty', { metaValue } );
-		return false;
-	}
-
 	// Version is an incrementing integer. If the client is ahead of the persisted
 	// version, it should be ignored. @TODO: If the client is behind, we may want
 	// to notify the user to refresh.
-	if ( 'number' !== typeof metaValue.version || metaValue.version !== expectedVersion ) {
+	if ( metaValue.version !== expectedVersion ) {
 		logger.warn( 'Persisted CRDT document version mismatch', { expectedVersion, metaValue } );
 		return false;
 	}
@@ -151,6 +191,67 @@ export function getPersistedCrdtDocFromEntityMeta(
 	expectedVersion: number
 ): CRDTDoc | null {
 	try {
+		const metaValue: PersistedCrdtDocMetaValue | null = getRawCRDTDocMetaValue( entityMeta );
+
+		if (
+			! metaValue ||
+			! isValidCrdtDocMetaContent( metaValue, expectedContentHash, expectedVersion )
+		) {
+			return null;
+		}
+
+		return deserializeCrdtDoc( metaValue.crdtDoc, metaValue.version );
+	} catch {
+		return null;
+	}
+}
+
+export function overrideFromCRDTDocStringToCRDTDoc(
+	sourceCrdtDocString: string,
+	destinationCrdtDoc: CRDTDoc,
+	syncConfig: SyncConfig
+): void {
+	// Properties that could cause footguns if copied over.
+	const propertiesToSkip = [ 'slug', 'generated_slug', '_links', 'meta' ];
+	const sourceCrdtDoc = deserializeCrdtDoc( sourceCrdtDocString );
+	const sourceYMap = sourceCrdtDoc.getMap( 'document' );
+	const destinationYMap = destinationCrdtDoc.getMap( 'document' );
+
+	syncConfig.syncedProperties.forEach( property => {
+		if ( propertiesToSkip.includes( property ) ) {
+			return;
+		}
+
+		if ( property === 'blocks' ) {
+			const currentBlocks = ( sourceYMap.get( 'blocks' ) as Y.Array< YBlock > ).clone();
+			destinationYMap.set( 'blocks', currentBlocks );
+		} else if ( property === 'title' ) {
+			// ToDo: Title sometimes doesn't get updated correctly. Need to investigate this further
+			const currentTitle = sourceYMap.get( 'title' ) as string;
+			logger.debug( 'Setting title from restored revision', { property, currentTitle } );
+			destinationYMap.set( 'title', currentTitle );
+		} else if ( destinationYMap.has( property ) && ! sourceYMap.has( property ) ) {
+			// This for properties that have been added in the future.
+			destinationYMap.delete( property );
+		} else if ( sourceYMap.has( property ) && sourceYMap.get( property ) !== undefined ) {
+			// This is for properties that have been deleted in the future or have updated.
+			const propertyValue = sourceYMap.get( property );
+			destinationYMap.set( property, propertyValue );
+		}
+	} );
+
+	sourceCrdtDoc.destroy();
+}
+
+/**
+ * Extract the raw PersistedCrdtDocMetaValue from entity meta, and validate its shape.
+ *
+ * This does not validate the contents of the meta value, like the content hash or version.
+ */
+export function getRawCRDTDocMetaValue(
+	entityMeta: Record< string, unknown >
+): PersistedCrdtDocMetaValue | null {
+	try {
 		if ( ! PERSISTED_STATE_POST_META_KEY ) {
 			logger.error( 'Persisted post meta key is undefined' );
 			return null;
@@ -165,11 +266,11 @@ export function getPersistedCrdtDocFromEntityMeta(
 
 		const metaValue: unknown = JSON.parse( rawMetaValue );
 
-		if ( ! isValidCrdtDocMetaValueShape( metaValue, expectedContentHash, expectedVersion ) ) {
+		if ( ! isValidCrdtDocMetaShape( metaValue ) ) {
 			return null;
 		}
 
-		return deserializeCrdtDoc( metaValue.crdtDoc, metaValue.version );
+		return metaValue;
 	} catch {
 		return null;
 	}

--- a/src/utilities/crdt.ts
+++ b/src/utilities/crdt.ts
@@ -212,7 +212,7 @@ export function overrideFromCRDTDocStringToCRDTDoc(
 	syncConfig: SyncConfig
 ): void {
 	// Properties that could cause footguns if copied over.
-	const propertiesToSkip = [ 'slug', 'generated_slug', '_links', 'meta' ];
+	const propertiesToSkip = [ '_links', 'meta' ];
 	const sourceCrdtDoc = deserializeCrdtDoc( sourceCrdtDocString );
 	const sourceYMap = sourceCrdtDoc.getMap( 'document' );
 	const destinationYMap = destinationCrdtDoc.getMap( 'document' );
@@ -227,8 +227,9 @@ export function overrideFromCRDTDocStringToCRDTDoc(
 			destinationYMap.set( 'blocks', currentBlocks );
 		} else if ( property === 'title' ) {
 			// ToDo: Title sometimes doesn't get updated correctly. Need to investigate this further
-			const currentTitle = sourceYMap.get( 'title' ) as string;
+			const currentTitle = sourceYMap.get( 'title' );
 			logger.debug( 'Setting title from restored revision', { property, currentTitle } );
+			destinationYMap.delete( 'title' );
 			destinationYMap.set( 'title', currentTitle );
 		} else if ( destinationYMap.has( property ) && ! sourceYMap.has( property ) ) {
 			// This for properties that have been added in the future.

--- a/src/utilities/crdt.ts
+++ b/src/utilities/crdt.ts
@@ -27,6 +27,7 @@ interface PersistedCrdtDocMetaValue {
 	contentHash: string;
 	crdtDoc: string;
 	version: number;
+	lastRevisionId: number;
 }
 
 const logger = new Logger( 'crdt' );
@@ -98,12 +99,14 @@ function isValidCrdtDocMetaValueShape(
  */
 function createCrdtDocMetaValue(
 	crdtDoc: CRDTDoc,
-	contentHash: string
+	contentHash: string,
+	lastRevisionId: number
 ): PersistedCrdtDocMetaValue {
 	return {
 		contentHash,
 		crdtDoc: serializeCrdtDoc( crdtDoc ),
 		version: getCrdtDocVersion( crdtDoc ),
+		lastRevisionId,
 	};
 }
 
@@ -113,9 +116,10 @@ function createCrdtDocMetaValue(
  */
 export function createPersistedCrdtDocMetaRecord(
 	crdtDoc: CRDTDoc,
-	contentHash: string
+	contentHash: string,
+	lastRevisionId: number
 ): EntityMetaRecord {
-	const metaValue = createCrdtDocMetaValue( crdtDoc, contentHash );
+	const metaValue = createCrdtDocMetaValue( crdtDoc, contentHash, lastRevisionId );
 
 	return {
 		[ PERSISTED_STATE_POST_META_KEY ]: JSON.stringify( metaValue ),
@@ -145,7 +149,7 @@ export function getPersistedCrdtDocFromEntityMeta(
 		// eslint-disable-next-line security/detect-object-injection
 		const rawMetaValue: unknown = entityMeta[ PERSISTED_STATE_POST_META_KEY ] ?? null;
 
-		if ( 'string' !== typeof rawMetaValue ) {
+		if ( 'string' !== typeof rawMetaValue || rawMetaValue === '' ) {
 			return null;
 		}
 

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -5,6 +5,17 @@ import { generateHash } from '@/utilities/crypto';
 
 import type { WordPressUserInfo } from '@/store/awareness-store';
 import type { ObjectData } from '@wordpress/sync';
+import { BlockInstance, parse } from '@wordpress/blocks';
+
+interface BlockAttributes {
+	[ key: string ]: unknown;
+}
+
+interface Block {
+	attributes: BlockAttributes;
+	innerBlocks: Block[];
+	name: string;
+}
 
 export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 	const { avatar_urls: avatarUrls, id, name } = select( coreStore ).getCurrentUser() ?? {};
@@ -21,14 +32,35 @@ export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 }
 
 export async function getHashForEntityRecord( record: ObjectData ): Promise< string > {
+	// console.debug( 'Calculating hash for record', record );
+
 	const content = getRawValueFromEntityRecord( record, 'content' ) ?? '';
 	const title = getRawValueFromEntityRecord( record, 'title' ) ?? '';
+	// const blocks: Block[] = removeClientIdsFromBlocks( 	parse( content ) );
+
+	// console.log( 'Blocks after removing client IDs: ', blocks );
+
+	// console.debug( 'Calculating hash using', { content, title /**, blocks */ } );
 
 	// Add more record fields that should invalidate a persisted CRDT doc here. In
 	// the future, this should be controlled by the entity's sync config.
 
-	const hashInput = JSON.stringify( { content, title } );
+	const hashInput = JSON.stringify( { content, title /**, blocks */ } );
 	return await generateHash( hashInput, 'SHA-256' );
+}
+
+function removeClientIdsFromBlocks( blocks: BlockInstance[] ): Block[] {
+	if ( ! blocks || 0 === blocks.length ) {
+		return [];
+	}
+
+	return blocks.map( ( block ) => {
+		const { clientId, innerBlocks, ...rest } = block;
+		return {
+			...rest,
+			innerBlocks: removeClientIdsFromBlocks( innerBlocks ),
+		};
+	} );
 }
 
 /**

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -45,7 +45,7 @@ export async function getHashForEntityRecord(
 	return await generateHash( hashInput, 'SHA-256' );
 }
 
-function getLastRevisionIDFromEntityRecord( record: ObjectData ): number | null {
+export function getLastRevisionIDFromEntityRecord( record: ObjectData ): number | null {
 	if (
 		'_links' in record &&
 		record._links &&
@@ -65,10 +65,10 @@ export function updateEntityFromRevisionIfRestored(
 	record: ObjectData,
 	crdtDoc: CRDTDoc,
 	syncConfig: SyncConfig
-): void {
+): boolean {
 	const currentLastRevisionId = getLastRevisionIDFromEntityRecord( record );
 	if ( ! currentLastRevisionId ) {
-		return;
+		return false;
 	}
 
 	const entityMeta = getMetaFromEntityRecord( record );
@@ -76,7 +76,7 @@ export function updateEntityFromRevisionIfRestored(
 	const vipMeta = getRawCRDTDocMetaValue( entityMeta );
 
 	if ( ! vipMeta || ! vipMeta.lastRevisionId ) {
-		return;
+		return false;
 	}
 
 	const expectedLastRevisionId = vipMeta.lastRevisionId;
@@ -85,7 +85,7 @@ export function updateEntityFromRevisionIfRestored(
 	// A difference of 1 or 0 means it's not a revision, and/or an auto-save just occurred.
 	// In either case, it's to be ignored.
 	if ( Math.abs( expectedLastRevisionId - currentLastRevisionId ) <= 1 ) {
-		return;
+		return false;
 	}
 
 	logger.debug( 'Entity has been restored from revision, overriding initial remote updates.', {
@@ -93,7 +93,10 @@ export function updateEntityFromRevisionIfRestored(
 		currentLastRevisionId,
 	} );
 
+	// Override the CRDT document with the content from the restored revision.
 	overrideFromCRDTDocStringToCRDTDoc( vipMeta.crdtDoc, crdtDoc, syncConfig );
+
+	return true;
 }
 
 /**

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -1,10 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { Logger } from '@/utilities/logger';
+import { generateHash } from '@/utilities/crypto';
+import type { WordPressUserInfo } from '@/store/awareness-store';
+
+/**
+ * WordPress dependencies
+ */
 import { store as coreStore } from '@wordpress/core-data';
 import { select } from '@wordpress/data';
+import type { ObjectData, CRDTDoc, SyncConfig } from '@wordpress/sync';
+import { getRawCRDTDocMetaValue, overrideFromCRDTDocStringToCRDTDoc } from './crdt';
 
-import { generateHash } from '@/utilities/crypto';
-
-import type { WordPressUserInfo } from '@/store/awareness-store';
-import type { ObjectData } from '@wordpress/sync';
+const logger = new Logger( 'entity' );
 
 export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 	const { avatar_urls: avatarUrls, id, name } = select( coreStore ).getCurrentUser() ?? {};
@@ -34,6 +43,57 @@ export async function getHashForEntityRecord(
 	);
 
 	return await generateHash( hashInput, 'SHA-256' );
+}
+
+function getLastRevisionIDFromEntityRecord( record: ObjectData ): number | null {
+	if (
+		'_links' in record &&
+		record._links &&
+		'object' === typeof record._links &&
+		'predecessor-version' in record._links &&
+		Array.isArray( record._links[ 'predecessor-version' ] ) &&
+		record._links[ 'predecessor-version' ].length > 0 &&
+		'id' in record._links[ 'predecessor-version' ][ 0 ]
+	) {
+		return record._links[ 'predecessor-version' ][ 0 ].id;
+	}
+
+	return null;
+}
+
+export function updateEntityFromRevisionIfRestored(
+	record: ObjectData,
+	crdtDoc: CRDTDoc,
+	syncConfig: SyncConfig
+): void {
+	const currentLastRevisionId = getLastRevisionIDFromEntityRecord( record );
+	if ( ! currentLastRevisionId ) {
+		return;
+	}
+
+	const entityMeta = getMetaFromEntityRecord( record );
+
+	const vipMeta = getRawCRDTDocMetaValue( entityMeta );
+
+	if ( ! vipMeta || ! vipMeta.lastRevisionId ) {
+		return;
+	}
+
+	const expectedLastRevisionId = vipMeta.lastRevisionId;
+
+	// The difference should be at least more than 1 to be a revision.
+	// A difference of 1 or 0 means it's not a revision, and/or an auto-save just occurred.
+	// In either case, it's to be ignored.
+	if ( Math.abs( expectedLastRevisionId - currentLastRevisionId ) <= 1 ) {
+		return;
+	}
+
+	logger.debug( 'Entity has been restored from revision, overriding initial remote updates.', {
+		expectedLastRevisionId,
+		currentLastRevisionId,
+	} );
+
+	overrideFromCRDTDocStringToCRDTDoc( vipMeta.crdtDoc, crdtDoc, syncConfig );
 }
 
 /**

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -6,16 +6,6 @@ import { generateHash } from '@/utilities/crypto';
 import type { WordPressUserInfo } from '@/store/awareness-store';
 import type { ObjectData } from '@wordpress/sync';
 
-interface BlockAttributes {
-	[ key: string ]: unknown;
-}
-
-interface Block {
-	attributes: BlockAttributes;
-	innerBlocks: Block[];
-	name: string;
-}
-
 export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 	const { avatar_urls: avatarUrls, id, name } = select( coreStore ).getCurrentUser() ?? {};
 

--- a/src/yjs-shim.ts
+++ b/src/yjs-shim.ts
@@ -26,3 +26,4 @@ export const encodeStateVector = window.wp.sync.Y.encodeStateVector;
 export const encodeStateAsUpdate = window.wp.sync.Y.encodeStateAsUpdate;
 export const encodeStateAsUpdateV2 = window.wp.sync.Y.encodeStateAsUpdateV2;
 export const Doc = window.wp.sync.Y.Doc;
+export const Text = window.wp.sync.Y.Text;

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { promise } from 'lib0';
 import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 
@@ -70,5 +71,10 @@ declare module '@wordpress/sync' {
 			record: ObjectData,
 			expectedVersion: number
 		): Promise< CRDTDoc | null >;
+		protected overrideInitialRemoteUpdates(
+			syncConfig: SyncConfig,
+			record: ObjectData,
+			initialYDoc: CRDTDoc
+		): Promise< void >;
 	}
 }


### PR DESCRIPTION
### Description

The purpose of this PR is to fix the revision functionality. This is a companion PR to [this Gutenberg PR](https://github.com/Automattic/gutenberg/pull/24).

It stores the last revision ID in the post meta, alongside the CRDT Doc details.

This also disables the _edit_lock meta that's used for locking revision functionality to a single user. It doesn't work anywhere else.

### ToDo

- The title doesn't get set correctly sometimes. I haven't been able to resolve this. It seems like the other remote clients are overriding it and my fix used for the blocks doesn't work here as this is a string.
- Verify that the way I'm updating the `vip_rtc_state` is correct, after a revision restore is detected. For us, a restore means the doc is updated so all of that would need to be updated. However, when the next save happens all of this would be re-verified anyways.
- Code cleanup and testing again to make sure I didn't miss anything.