### PR TITLE
Add GitHub codeowners and dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # See https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# This team will be requested for review when someone opens a pull request.
 * @Automattic/vip-cafe
+
+# Don't assign owners for the following files:
+package.json
+package-lock.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+* @Automattic/vip-cafe

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    groups:
+      wordpress:
+        patterns:
+          - '@wordpress/*'
+
+  - package-ecosystem: 'composer'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,19 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
+
+  - package-ecosystem: 'npm'
+    directory: '/websocket-server'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+
+  - package-ecosystem: 'npm'
+    directory: '/yjs-inspector'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']


### PR DESCRIPTION
Mostly taken from https://github.com/Automattic/remote-data-blocks with additional dependabot configs for `websocket-server` and `yjs-inspector` which also live in this repo.