### PR TITLE
Add Telemetry class

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Psalm
-        uses: docker://ghcr.io/psalm/psalm-github-actions:6.5.1
+        uses: docker://ghcr.io/psalm/psalm-github-actions
         with:
           composer_require_dev: true
           php-version: '8.2'

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
   "autoload-dev": {
     "psr-4": {
       "VIPRealTimeCollaboration\\Tests\\": "tests/"
-    }
+    },
+    "classmap": [
+      "tests/inc/"
+    ]
   }
 }

--- a/inc/Telemetry/Telemetry.php
+++ b/inc/Telemetry/Telemetry.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types = 1);
+
+namespace VIPRealTimeCollaboration\Telemetry;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Class to implement telemetry on WordPress VIP.
+ */
+final class Telemetry {
+	private const EVENT_PREFIX = 'viprealtimecollaboration_';
+	private static ?self $instance = null;
+
+	private function __construct( private string $plugin_path, private ?object $telemetry = null ) {}
+
+	/**
+	 * Initializes telemetry for the plugin. The Telemetry library is provided
+	 * by VIP mu-plugins and only runs in approved environments.
+	 *
+	 * @param string $plugin_path Plugin path.
+	 * @param object|null $telemetry Telemetry instance. If null, we will attempt to create one.
+	 */
+	public static function init( string $plugin_path, ?object $telemetry = null ): void {
+		if ( isset( self::$instance ) ) {
+			return;
+		}
+
+		if ( null === $telemetry && class_exists( '\Automattic\VIP\Telemetry\Telemetry' ) ) {
+			$telemetry = new \Automattic\VIP\Telemetry\Telemetry( self::EVENT_PREFIX, self::get_global_properties() );
+		}
+
+		self::$instance = new self( $plugin_path, $telemetry );
+		self::$instance->setup_tracking_via_hooks();
+	}
+
+	/**
+	 * Gets global event properties. These properties are sent with each event.
+	 */
+	public static function get_global_properties(): array {
+		$plugin_version = defined( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION' ) ? constant( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION' ) : 'unknown';
+
+		return [
+			'plugin_version' => $plugin_version,
+		];
+	}
+
+	/**
+	 * Sets up tracking via WordPress hooks.
+	 */
+	private function setup_tracking_via_hooks(): void {
+		// WordPress hooks.
+		add_action( 'activated_plugin', [ $this, 'track_plugin_activation' ], 10, 1 );
+		add_action( 'deactivated_plugin', [ $this, 'track_plugin_deactivation' ], 10, 1 );
+
+		// Custom hook to allow other plugin code to track events
+		add_action( 'vip_real_time_collaboration_track_event', [ $this, 'record_event' ], 10, 2 );
+
+		// Enable the Pendo JavaScript library for tracking.
+		if ( class_exists( '\Automattic\VIP\Telemetry\Pendo' ) ) {
+			/** @psalm-suppress InvalidArgument */
+			add_action( 'admin_init', [ \Automattic\VIP\Telemetry\Pendo::class, 'enable_javascript_library' ] );
+		}
+	}
+
+	/**
+	 * Tracks plugin activation.
+	 *
+	 * @param string $plugin_path Path of the plugin that was activated.
+	 */
+	public function track_plugin_activation( string $plugin_path ): void {
+		if ( ! str_ends_with( $this->plugin_path, $plugin_path ) ) {
+			return;
+		}
+
+		$this->record_event( 'plugin_toggle', [ 'action' => 'activate' ] );
+	}
+
+	/**
+	 * Tracks plugin deactivation.
+	 *
+	 * @param string $plugin_path Path of the plugin that was deactivated.
+	 */
+	public function track_plugin_deactivation( string $plugin_path ): void {
+		if ( ! str_ends_with( $this->plugin_path, $plugin_path ) ) {
+			return;
+		}
+
+		$this->record_event( 'plugin_toggle', [ 'action' => 'deactivate' ] );
+	}
+
+	/**
+	 * Records a telemetry event.
+	 *
+	 * @param string $event_name The name of the event.
+	 * @param array  $props      The properties to send with the event.
+	 */
+	public function record_event( string $event_name, array $props ): void {
+		if ( null === $this->telemetry ) {
+			return;
+		}
+
+		/** @psalm-suppress MixedMethodCall */
+		$this->telemetry->record_event( $event_name, $props );
+	}
+
+	/**
+	 * Resets class properties.
+	 */
+	public static function reset(): void {
+		self::$instance = null;
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -31,6 +31,11 @@
         <file name="vip-real-time-collaboration.php"/>
     </stubs>
     <issueHandlers>
+        <PossiblyUnusedMethod>
+            <errorLevel type="suppress">
+                <file name="inc/Telemetry/Telemetry.php" />
+            </errorLevel>
+        </PossiblyUnusedMethod>
         <PossiblyUnusedParam>
             <errorLevel type="suppress">
                 <file name="tests/Traits/ReflectionUtils.php" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,7 +27,7 @@
     <stubs>
         <file name="vendor/php-stubs/wordpress-globals/wordpress-globals.php"/>
         <file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php"/>
-		<file name="vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php"/>
+        <file name="vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php"/>
         <file name="vip-real-time-collaboration.php"/>
     </stubs>
     <issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -31,6 +31,11 @@
         <file name="vip-real-time-collaboration.php"/>
     </stubs>
     <issueHandlers>
+        <ClassMustBeFinal>
+            <errorLevel type="suppress">
+                <directory name="tests/inc/Mocks/" />
+            </errorLevel>
+        </ClassMustBeFinal>
         <PossiblyUnusedMethod>
             <errorLevel type="suppress">
                 <file name="inc/Telemetry/Telemetry.php" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -36,9 +36,14 @@
                 <file name="tests/Traits/ReflectionUtils.php" />
             </errorLevel>
         </PossiblyUnusedParam>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <file name="inc/Telemetry/Telemetry.php" />
+            </errorLevel>
+        </UndefinedClass>
         <UnusedClass>
             <errorLevel type="suppress">
-                <directory name="tests/Integration" />
+                <directory name="tests/" />
             </errorLevel>
         </UnusedClass>
     </issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="1"
-    resolveFromConfigFile="true"
-    phpVersion="8.1"
-    allConstantsGlobal="true"
-    allFunctionsGlobal="true"
-    findUnusedCode="true"
-    findUnusedBaselineEntry="true"
-    findUnusedPsalmSuppress="true"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+	errorLevel="1"
+	resolveFromConfigFile="true"
+	phpVersion="8.1"
+	allConstantsGlobal="true"
+	allFunctionsGlobal="true"
+	findUnusedCode="true"
+	findUnusedBaselineEntry="true"
+	findUnusedPsalmSuppress="true"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="https://getpsalm.org/schema/config"
+	xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
-    <projectFiles>
-        <file name="*.php"/>
-        <directory name="*"/>
-        <ignoreFiles allowMissingFiles="true">
-            <directory name="build/"/>
-            <directory name="examples/**/build/"/>
-            <directory name="examples/**/node_modules/"/>
-            <directory name="node_modules/"/>
-            <directory name="vendor/"/>
-            <directory name="yjs-inspector/"/>
-        </ignoreFiles>
-    </projectFiles>
-    <stubs>
-        <file name="vendor/php-stubs/wordpress-globals/wordpress-globals.php"/>
-        <file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php"/>
-        <file name="vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php"/>
-        <file name="vip-real-time-collaboration.php"/>
-    </stubs>
-    <issueHandlers>
-        <ClassMustBeFinal>
-            <errorLevel type="suppress">
-                <directory name="tests/inc/Mocks/" />
-            </errorLevel>
-        </ClassMustBeFinal>
-        <PossiblyUnusedMethod>
-            <errorLevel type="suppress">
-                <file name="inc/Telemetry/Telemetry.php" />
-            </errorLevel>
-        </PossiblyUnusedMethod>
-        <PossiblyUnusedParam>
-            <errorLevel type="suppress">
-                <file name="tests/Traits/ReflectionUtils.php" />
-            </errorLevel>
-        </PossiblyUnusedParam>
-        <UndefinedClass>
-            <errorLevel type="suppress">
-                <file name="inc/Telemetry/Telemetry.php" />
-            </errorLevel>
-        </UndefinedClass>
-        <UnusedClass>
-            <errorLevel type="suppress">
-                <directory name="tests/" />
-            </errorLevel>
-        </UnusedClass>
-    </issueHandlers>
+	<projectFiles>
+		<file name="*.php"/>
+		<directory name="*"/>
+		<ignoreFiles allowMissingFiles="true">
+			<directory name="build/"/>
+			<directory name="examples/**/build/"/>
+			<directory name="examples/**/node_modules/"/>
+			<directory name="node_modules/"/>
+			<directory name="vendor/"/>
+			<directory name="yjs-inspector/"/>
+		</ignoreFiles>
+	</projectFiles>
+	<stubs>
+		<file name="vendor/php-stubs/wordpress-globals/wordpress-globals.php"/>
+		<file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php"/>
+		<file name="vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php"/>
+		<file name="vip-real-time-collaboration.php"/>
+	</stubs>
+	<issueHandlers>
+		<ClassMustBeFinal>
+			<errorLevel type="suppress">
+				<directory name="tests/inc/Mocks/" />
+			</errorLevel>
+		</ClassMustBeFinal>
+		<PossiblyUnusedMethod>
+			<errorLevel type="suppress">
+				<file name="inc/Telemetry/Telemetry.php" />
+			</errorLevel>
+		</PossiblyUnusedMethod>
+		<PossiblyUnusedParam>
+			<errorLevel type="suppress">
+				<file name="tests/Traits/ReflectionUtils.php" />
+			</errorLevel>
+		</PossiblyUnusedParam>
+		<UndefinedClass>
+			<errorLevel type="suppress">
+				<file name="inc/Telemetry/Telemetry.php" />
+			</errorLevel>
+		</UndefinedClass>
+		<UnusedClass>
+			<errorLevel type="suppress">
+				<directory name="tests/" />
+			</errorLevel>
+		</UnusedClass>
+	</issueHandlers>
 </psalm>

--- a/tests/Integration/Telemetry/TelemetryTest.php
+++ b/tests/Integration/Telemetry/TelemetryTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace VIPRealTimeCollaboration\Tests\Integration\Telemetry;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use VIPRealTimeCollaboration\Telemetry\Telemetry;
+use VIPRealTimeCollaboration\Tests\Mocks\MockTelemetry;
+use WP_UnitTestCase;
+
+use function do_action;
+
+final class TelemetryTest extends WP_UnitTestCase {
+	private string $plugin_path;
+	private MockObject $mock_telemetry;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->plugin_path = '/path/to/plugin';
+		$this->mock_telemetry = $this->createMock( MockTelemetry::class );
+		Telemetry::reset();
+	}
+
+	/**
+	 * Verifies that plugin activation gets logged by telemetry.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Telemetry\Telemetry::track_plugin_activation
+	 */
+	public function test_track_plugin_activation_calls_record_event(): void {
+		$this->mock_telemetry
+			->expects( $this->once() )
+			->method( 'record_event' )
+			->with(
+				'plugin_toggle',
+				$this->equalTo( [ 'action' => 'activate' ] )
+			);
+
+		Telemetry::init( $this->plugin_path, $this->mock_telemetry );
+		do_action( 'activated_plugin', $this->plugin_path );
+	}
+
+	/**
+	 * Verifies that other plugin activations don't get logged by telemetry.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Telemetry\Telemetry::track_plugin_activation
+	 */
+	public function test_track_plugin_activation_does_not_call_record_event_for_other_plugins(): void {
+		$this->mock_telemetry
+			->expects( $this->never() )
+			->method( 'record_event' );
+
+		Telemetry::init( $this->plugin_path, $this->mock_telemetry );
+		do_action( 'activated_plugin', '/path/to/other-plugin' );
+	}
+
+	/**
+	 * Verifies that plugin deactivation gets logged by telemetry.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Telemetry\Telemetry::track_plugin_deactivation
+	 */
+	public function test_track_plugin_deactivation_calls_record_event(): void {
+		$this->mock_telemetry
+			->expects( $this->once() )
+			->method( 'record_event' )
+			->with(
+				'plugin_toggle',
+				$this->equalTo( [ 'action' => 'deactivate' ] )
+			);
+
+		Telemetry::init( $this->plugin_path, $this->mock_telemetry );
+		do_action( 'deactivated_plugin', $this->plugin_path );
+	}
+
+	/**
+	 * Verifies that other plugin deactivations don't get logged by telemetry.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Telemetry\Telemetry::track_plugin_deactivation
+	 */
+	public function test_track_plugin_deactivation_does_not_call_record_event_for_other_plugins(): void {
+		$this->mock_telemetry
+			->expects( $this->never() )
+			->method( 'record_event' );
+
+		Telemetry::init( $this->plugin_path, $this->mock_telemetry );
+		do_action( 'deactivated_plugin', '/path/to/other-plugin' );
+	}
+}

--- a/tests/inc/MockTelemetry.php
+++ b/tests/inc/MockTelemetry.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace VIPRealTimeCollaboration\Tests\Mocks;
+
+final class MockTelemetry {
+	public function record_event( string $_name, array $_props ): void {}
+}

--- a/tests/inc/Mocks/MockTelemetry.php
+++ b/tests/inc/Mocks/MockTelemetry.php
@@ -2,6 +2,6 @@
 
 namespace VIPRealTimeCollaboration\Tests\Mocks;
 
-final class MockTelemetry {
+class MockTelemetry {
 	public function record_event( string $_name, array $_props ): void {}
 }

--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -35,6 +35,9 @@ define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION', '0.1.0' );
 // Autoloader
 require_once __DIR__ . '/vendor/autoload.php';
 
+// Telemetry
+Telemetry\Telemetry::init( __FILE__ );
+
 // Examples (must be manually built):
 // require_once __DIR__ . '/examples/local-updates-block/local-updates-block.php';
 // require_once __DIR__ . '/examples/post-meta-block/post-meta-block.php';


### PR DESCRIPTION
With this PR we're adding a local `Telemetry` class, which uses the [VIP Telemetry Library](https://github.com/Automattic/vip-go-mu-plugins/tree/develop/telemetry).

This work is largely based on the Telemetry codebase in https://github.com/Automattic/remote-data-blocks and specifically https://github.com/Automattic/remote-data-blocks/pull/452.