### PR TITLE
Fix CRDT doc invalidation and drop version check

### DIFF
--- a/inc/Editor/CrdtPersistence.php
+++ b/inc/Editor/CrdtPersistence.php
@@ -4,7 +4,6 @@ namespace VIPRealTimeCollaboration\Editor;
 
 use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use function add_action;
-use function post_type_supports;
 use function register_meta;
 
 defined( 'ABSPATH' ) || exit();
@@ -30,7 +29,15 @@ final class CrdtPersistence {
 						return user_can( $user_id, 'edit_post', $object_id );
 					},
 					'object_subtype' => $post_type,
-					'revisions_enabled' => post_type_supports( $post_type, 'revisions' ),
+					// IMPORTANT: Revisions must be disabled because we always want to
+					// preserve the latest persisted CRDT document, even when a revision
+					// is restored. This ensures that we can continue to apply updates to
+					// a shared document and peers can simply merge the restored revision
+					// like any other incoming update.
+					//
+					// If we want to persist CRDT documents alongisde revisions in the
+					// future, we should do so in a separate meta key.
+					'revisions_enabled' => false,
 					'show_in_rest' => true,
 					'single' => true,
 					'type' => 'string',

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts",
     "test:e2e:debug": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts --ui",
     "test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/vip-real-time-collaboration ./vendor/bin/phpunit -c ./phpunit-integration.xml",
-    "test:js:unit": "npx tsx --test \"src/**/*.test.ts\"",
+    "test:js:unit": "npx tsx --experimental-test-module-mocks --test \"src/**/*.test.ts\"",
     "wp-cli": "wp-env run cli -- wp"
   },
   "devDependencies": {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -4,7 +4,6 @@
 import { AwarenessManager } from '@/awareness-manager';
 import {
 	createPersistedCrdtDocMetaRecord,
-	getCrdtDocVersion,
 	getPersistedCrdtDocFromEntityMeta,
 	type EntityMetaRecord,
 } from '@/utilities/crdt';
@@ -53,25 +52,21 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 
 	public async createEntityMeta(
 		syncConfig: SyncConfig,
-		record: ObjectData,
-		changes: Partial< ObjectData >
+		rawRecord: ObjectData
 	): Promise< EntityMetaRecord > {
 		if ( ! syncConfig.supports?.crdtPersistence ) {
 			return {};
 		}
 
-		const objectId = syncConfig.getObjectId( record ).toString();
+		const objectId = syncConfig.getObjectId( rawRecord ).toString();
 		const objectType = syncConfig.objectType.toString();
 		const ydoc = this.entityStates.get( this.getEntityId( objectType, objectId ) )?.ydoc;
 
-		if ( ! ydoc || 'auto-draft' === record.status ) {
+		if ( ! ydoc || 'auto-draft' === rawRecord.status ) {
 			return {};
 		}
 
-		const contentHash = await getHashForEntityRecord(
-			{ ...record, ...changes },
-			syncConfig.syncedProperties
-		);
+		const contentHash = await getHashForEntityRecord( rawRecord, syncConfig );
 		const entityMeta = createPersistedCrdtDocMetaRecord( ydoc, contentHash );
 
 		this.logger.debug( 'Providing updated entity meta to saveEntityRecord', {
@@ -85,24 +80,19 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 
 	protected async getPersistedCRDTDoc(
 		syncConfig: SyncConfig,
-		record: ObjectData,
-		expectedVersion: number
+		rawRecord: ObjectData
 	): Promise< CRDTDoc | null > {
 		if ( ! syncConfig.supports?.crdtPersistence ) {
 			return Promise.resolve( null );
 		}
 
-		const objectId = syncConfig.getObjectId( record ).toString();
+		const objectId = syncConfig.getObjectId( rawRecord ).toString();
 		const objectType = syncConfig.objectType.toString();
-		const entityMeta = getMetaFromEntityRecord( record );
+		const entityMeta = getMetaFromEntityRecord( rawRecord );
 
 		// Attempt to load the initial CRDT document from post meta.
-		const expectedHash = await getHashForEntityRecord( record, syncConfig.syncedProperties );
-		const persistedDoc = getPersistedCrdtDocFromEntityMeta(
-			entityMeta,
-			expectedHash,
-			expectedVersion
-		);
+		const expectedHash = await getHashForEntityRecord( rawRecord, syncConfig );
+		const persistedDoc = getPersistedCrdtDocFromEntityMeta( entityMeta, expectedHash );
 
 		const logMessage = persistedDoc
 			? 'Found persisted CRDT doc in entity meta'
@@ -111,7 +101,6 @@ export class SyncProviderWithAwareness extends window.wp.sync.SyncProvider {
 			objectType,
 			objectId,
 			persistedDoc,
-			version: persistedDoc ? getCrdtDocVersion( persistedDoc ) : null,
 		} );
 
 		return Promise.resolve( persistedDoc );

--- a/src/utilities/crdt.ts
+++ b/src/utilities/crdt.ts
@@ -20,13 +20,9 @@ interface PersistedCrdtDocMetaValue {
 	 * This content hash is used to invalidate the CRDT document in case the record
 	 * has meaningfully changed "out-of-band" (example: via a WP-CLI command that
 	 * mutates content).
-	 *
-	 * Client-side code changes (e.g., to applyChangesToDoc) may also require
-	 * invalidation, but that should happen via an incremented `version` number.
 	 */
 	contentHash: string;
 	crdtDoc: string;
-	version: number;
 }
 
 const logger = new Logger( 'crdt' );
@@ -35,8 +31,8 @@ function serializeCrdtDoc( crdtDoc: CRDTDoc ): string {
 	return buffer.toBase64( Y.encodeStateAsUpdateV2( crdtDoc ) );
 }
 
-function deserializeCrdtDoc( serializedCrdtDoc: string, version = 0 ): CRDTDoc {
-	const docMeta = new Map< string, unknown >( [ [ 'version', version ] ] );
+function deserializeCrdtDoc( serializedCrdtDoc: string ): CRDTDoc {
+	const docMeta = new Map< string, unknown >();
 	const ydoc = new Y.Doc( { meta: docMeta } );
 	const yupdate = buffer.fromBase64( serializedCrdtDoc );
 	Y.applyUpdateV2( ydoc, yupdate );
@@ -48,20 +44,18 @@ function deserializeCrdtDoc( serializedCrdtDoc: string, version = 0 ): CRDTDoc {
 
 /**
  * Type predicate to check the deserialized entity meta value shape. This does
- * not validate the CRDT document itself, but it does validate the content hash
- * and document version.
+ * not validate the CRDT document itself, but it does validate the content hash.
  */
-function isValidCrdtDocMetaValueShape(
+function isValidCrdtDocMetaValue(
 	metaValue: unknown,
-	expectedContentHash: string,
-	expectedVersion: number
+	expectedContentHash: string
 ): metaValue is PersistedCrdtDocMetaValue {
 	if ( 'object' !== typeof metaValue || null === metaValue ) {
 		logger.debug( 'Persisted CRDT document was not found', { metaValue } );
 		return false;
 	}
 
-	if ( ! ( 'contentHash' in metaValue && 'crdtDoc' in metaValue && 'version' in metaValue ) ) {
+	if ( ! ( 'contentHash' in metaValue && 'crdtDoc' in metaValue ) ) {
 		logger.error( 'Persisted CRDT document is missing expected properties', { metaValue } );
 		return false;
 	}
@@ -82,14 +76,6 @@ function isValidCrdtDocMetaValueShape(
 		return false;
 	}
 
-	// Version is an incrementing integer. If the client is ahead of the persisted
-	// version, it should be ignored. @TODO: If the client is behind, we may want
-	// to notify the user to refresh.
-	if ( 'number' !== typeof metaValue.version || metaValue.version !== expectedVersion ) {
-		logger.warn( 'Persisted CRDT document version mismatch', { expectedVersion, metaValue } );
-		return false;
-	}
-
 	return true;
 }
 
@@ -103,7 +89,6 @@ function createCrdtDocMetaValue(
 	return {
 		contentHash,
 		crdtDoc: serializeCrdtDoc( crdtDoc ),
-		version: getCrdtDocVersion( crdtDoc ),
 	};
 }
 
@@ -128,23 +113,11 @@ export function createPersistedCrdtDocMetaRecord(
 }
 
 /**
- * Get a CRDT document's version from document meta.
- */
-export function getCrdtDocVersion( crdtDoc: CRDTDoc ): number {
-	// Y.Doc.meta is untyped
-	const version: unknown = ( crdtDoc.meta as Map< string, unknown > | null )?.get( 'version' );
-	const fallbackVersion = 0;
-
-	return 'number' === typeof version ? version : fallbackVersion;
-}
-
-/**
  * Extract and validate a persisted CRDT document from entity meta.
  */
 export function getPersistedCrdtDocFromEntityMeta(
 	entityMeta: Record< string, unknown >,
-	expectedContentHash: string,
-	expectedVersion: number
+	expectedContentHash: string
 ): CRDTDoc | null {
 	try {
 		if ( ! PERSISTED_STATE_POST_META_KEY ) {
@@ -161,11 +134,11 @@ export function getPersistedCrdtDocFromEntityMeta(
 
 		const metaValue: unknown = JSON.parse( rawMetaValue );
 
-		if ( ! isValidCrdtDocMetaValueShape( metaValue, expectedContentHash, expectedVersion ) ) {
+		if ( ! isValidCrdtDocMetaValue( metaValue, expectedContentHash ) ) {
 			return null;
 		}
 
-		return deserializeCrdtDoc( metaValue.crdtDoc, metaValue.version );
+		return deserializeCrdtDoc( metaValue.crdtDoc );
 	} catch {
 		return null;
 	}

--- a/src/utilities/crdt.ts
+++ b/src/utilities/crdt.ts
@@ -31,9 +31,12 @@ function serializeCrdtDoc( crdtDoc: CRDTDoc ): string {
 	return buffer.toBase64( Y.encodeStateAsUpdateV2( crdtDoc ) );
 }
 
-function deserializeCrdtDoc( serializedCrdtDoc: string ): CRDTDoc {
-	const docMeta = new Map< string, unknown >();
-	const ydoc = new Y.Doc( { meta: docMeta } );
+function deserializeCrdtDoc(
+	serializedCrdtDoc: string,
+	documentMeta: Record< string, unknown > = {}
+): CRDTDoc {
+	const metaMap = new Map< string, unknown >( Object.entries( documentMeta ) );
+	const ydoc = new Y.Doc( { meta: metaMap } );
 	const yupdate = buffer.fromBase64( serializedCrdtDoc );
 	Y.applyUpdateV2( ydoc, yupdate );
 
@@ -44,11 +47,10 @@ function deserializeCrdtDoc( serializedCrdtDoc: string ): CRDTDoc {
 
 /**
  * Type predicate to check the deserialized entity meta value shape. This does
- * not validate the CRDT document itself, but it does validate the content hash.
+ * not validate the CRDT document itself or the content hash.
  */
-function isValidCrdtDocMetaValue(
-	metaValue: unknown,
-	expectedContentHash: string
+function isValidCrdtDocMetaValueShape(
+	metaValue: unknown
 ): metaValue is PersistedCrdtDocMetaValue {
 	if ( 'object' !== typeof metaValue || null === metaValue ) {
 		logger.debug( 'Persisted CRDT document was not found', { metaValue } );
@@ -60,14 +62,8 @@ function isValidCrdtDocMetaValue(
 		return false;
 	}
 
-	if (
-		'string' !== typeof metaValue.contentHash ||
-		metaValue.contentHash !== expectedContentHash
-	) {
-		logger.warn( 'Persisted CRDT document content hash mismatch', {
-			expectedContentHash,
-			metaValue,
-		} );
+	if ( 'string' !== typeof metaValue.contentHash || ! metaValue.contentHash ) {
+		logger.warn( 'Persisted CRDT content hash is empty', { metaValue } );
 		return false;
 	}
 
@@ -134,11 +130,20 @@ export function getPersistedCrdtDocFromEntityMeta(
 
 		const metaValue: unknown = JSON.parse( rawMetaValue );
 
-		if ( ! isValidCrdtDocMetaValue( metaValue, expectedContentHash ) ) {
+		if ( ! isValidCrdtDocMetaValueShape( metaValue ) ) {
 			return null;
 		}
 
-		return deserializeCrdtDoc( metaValue.crdtDoc );
+		const documentMeta: Record< string, unknown > = {};
+
+		// If the meta value content hash does not match the expected hash, mark the
+		// document as invalidated.
+		if ( expectedContentHash !== metaValue.contentHash ) {
+			logger.debug( 'Persisted CRDT content hash mismatch', { expectedContentHash, metaValue } );
+			documentMeta.invalidated = true;
+		}
+
+		return deserializeCrdtDoc( metaValue.crdtDoc, documentMeta );
 	} catch {
 		return null;
 	}

--- a/src/utilities/entity.test.ts
+++ b/src/utilities/entity.test.ts
@@ -1,0 +1,146 @@
+import { SyncConfig, type ObjectData } from '@wordpress/sync';
+import assert from 'node:assert';
+import { afterEach, before, describe, it, mock, type Mock } from 'node:test';
+
+describe( 'getHashForEntityRecord', () => {
+	let getHashForEntityRecord: typeof import('./entity').getHashForEntityRecord;
+	let mockGenerateHash: Mock< typeof import('@/utilities/crypto').generateHash >;
+
+	const syncConfig: SyncConfig = {
+		getInitialObjectData: ( { content: _discard, ...record }: ObjectData ) => ( {
+			...record,
+			blocks: [ { type: 'paragraph', content: 'Block content' } ],
+		} ),
+		getObjectId: ( { id }: ObjectData ) => id as string,
+		objectType: 'test-type',
+		syncedProperties: new Set( [ 'id', 'title', 'content', 'blocks', 'date', 'slug' ] ),
+	};
+
+	before( async () => {
+		// These modules access browser globals in their top-level scope which makes
+		// it impossible to import the `./entity` module in this file's top-level
+		// scope. Therefore, we must mock them and then dynamically import the module
+		// under test.
+		mock.module( '@wordpress/core-data' );
+		mock.module( '@wordpress/data' );
+
+		mockGenerateHash = mock.fn( () => Promise.resolve( 'mocked-hash' ) );
+		mock.module( '@/utilities/crypto', {
+			namedExports: {
+				generateHash: mockGenerateHash,
+			},
+		} );
+
+		// @ts-expect-error: TS2702 Dynamic import -- used to navigate import issues mentioned above.
+		getHashForEntityRecord = ( await import( './entity' ) ).getHashForEntityRecord;
+	} );
+
+	afterEach( () => {
+		mockGenerateHash.mock.resetCalls();
+	} );
+
+	it( 'should ignore blocks property and include content from raw record', async () => {
+		const rawRecord = {
+			id: 1,
+			date: '2024-01-01T00:00:00',
+			title: 'Test Post',
+			content: 'Raw content from record',
+		};
+
+		await getHashForEntityRecord( rawRecord, syncConfig );
+
+		// Verify generateHash was called.
+		assert.strictEqual( mockGenerateHash.mock.callCount(), 1 );
+
+		const hashInput = mockGenerateHash.mock.calls[ 0 ]?.arguments[ 0 ];
+		const parsedInput = JSON.parse( hashInput ?? '{}' ) as Record< string, unknown >;
+
+		// Should not include blocks.
+		assert.strictEqual( parsedInput.blocks, undefined );
+
+		// Should include content from raw record.
+		assert.strictEqual( parsedInput.content, 'Raw content from record' );
+
+		// Should include other synced properties.
+		assert.strictEqual( parsedInput.id, 1 );
+		assert.strictEqual( parsedInput.date, '2024-01-01T00:00:00' );
+		assert.strictEqual( parsedInput.title, 'Test Post' );
+	} );
+
+	it( 'should sort object keys in the hash input', async () => {
+		const rawRecord1 = {
+			id: 1,
+			date: '2024-01-01T00:00:00',
+			title: 'Test Post',
+			content: 'Content',
+			slug: 'test-post',
+		};
+
+		const rawRecord2 = {
+			title: 'Test Post',
+			id: 1,
+			slug: 'test-post',
+			date: '2024-01-01T00:00:00',
+			content: 'Content',
+		};
+
+		await getHashForEntityRecord( rawRecord1, syncConfig );
+		await getHashForEntityRecord( rawRecord2, syncConfig );
+
+		// Verify generateHash was called twice.
+		assert.strictEqual( mockGenerateHash.mock.callCount(), 2 );
+
+		const hashInput1 = mockGenerateHash.mock.calls[ 0 ]?.arguments[ 0 ];
+		const hashInput2 = mockGenerateHash.mock.calls[ 1 ]?.arguments[ 0 ];
+
+		// Both inputs should be identical and valid JSON.
+		assert.strictEqual( hashInput1, hashInput2 );
+
+		const parsedInput1 = JSON.parse( hashInput1 ?? 'false' );
+		const parsedInput2 = JSON.parse( hashInput2 ?? 'false' );
+
+		assert.strictEqual( typeof parsedInput1, 'object' );
+		assert.strictEqual( typeof parsedInput2, 'object' );
+		assert.deepStrictEqual( parsedInput1, parsedInput2 );
+	} );
+
+	it( 'should handle content as object with raw property', async () => {
+		const rawRecord = {
+			id: 1,
+			title: 'Test Post',
+			content: { raw: 'Raw content from object', rendered: 'Rendered content' },
+		};
+
+		await getHashForEntityRecord( rawRecord, syncConfig );
+
+		const hashInput = mockGenerateHash.mock.calls[ 0 ]?.arguments[ 0 ];
+		const parsedInput = JSON.parse( hashInput ?? '{}' ) as Record< string, unknown >;
+
+		// Should extract raw content from object
+		assert.strictEqual( parsedInput.content, 'Raw content from object' );
+	} );
+
+	it( 'should handle missing content property', async () => {
+		const rawRecord = {
+			id: 1,
+			title: 'Test Post',
+		};
+
+		await getHashForEntityRecord( rawRecord, syncConfig );
+
+		const hashInput = mockGenerateHash.mock.calls[ 0 ]?.arguments[ 0 ];
+		const parsedInput = JSON.parse( hashInput ?? '{}' ) as Record< string, unknown >;
+
+		// Should default to empty string for missing content.
+		assert.strictEqual( parsedInput.content, '' );
+	} );
+
+	it( 'should pass correct algorithm to generateHash', async () => {
+		const rawRecord = { id: 1, title: 'Test' };
+
+		await getHashForEntityRecord( rawRecord, syncConfig );
+
+		// Verify generateHash was called with SHA-256 algorithm
+		assert.strictEqual( mockGenerateHash.mock.calls[ 0 ]?.arguments[ 1 ], 'SHA-256' );
+	} );
+} );

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -29,10 +29,13 @@ export async function getHashForEntityRecord(
 	// We remove the blocks and use the content as a proxy for the blocks, since
 	// blocks are a derived property with unstable identifiers (clientIds).
 	//
+	// We also remove the date since that is updated by the server on save and
+	// this hash must be computed before the record is saved.
+	//
 	// TODO: This should ideally be controlled by the SyncConfig, but since we
 	// don't yet want to introduce hashing utilities to Gutenberg, this logic will
 	// temporarily live here.
-	const { blocks: _discard, ...rest } = objectData;
+	const { blocks: _discard, date: _discard2, ...rest } = objectData;
 	const record = { ...rest, content: getRawStringValue( rawRecord, 'content' ) };
 
 	// Get a string representation of the object data. It should include only the

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -4,7 +4,7 @@ import { select } from '@wordpress/data';
 import { generateHash } from '@/utilities/crypto';
 
 import type { WordPressUserInfo } from '@/store/awareness-store';
-import type { ObjectData } from '@wordpress/sync';
+import type { ObjectData, SyncConfig } from '@wordpress/sync';
 
 export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 	const { avatar_urls: avatarUrls, id, name } = select( coreStore ).getCurrentUser() ?? {};
@@ -21,17 +21,24 @@ export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 }
 
 export async function getHashForEntityRecord(
-	record: ObjectData,
-	syncedProperties: Set< string >
+	rawRecord: ObjectData,
+	syncConfig: SyncConfig
 ): Promise< string > {
-	// Get a string representation of the record that includes only the properties
-	// that are synced. This is used to determine if the record has changed in a
+	const objectData = syncConfig.getInitialObjectData( rawRecord );
+
+	// We remove the blocks and use the content as a proxy for the blocks, since
+	// blocks are a derived property with unstable identifiers (clientIds).
+	//
+	// TODO: This should ideally be controlled by the SyncConfig, but since we
+	// don't yet want to introduce hashing utilities to Gutenberg, this logic will
+	// temporarily live here.
+	const { blocks: _discard, ...rest } = objectData;
+	const record = { ...rest, content: getRawStringValue( rawRecord, 'content' ) };
+
+	// Get a string representation of the object data. It should include only the
+	// synced properties. This is used to determine if the record has changed in a
 	// meaningful way that should invalidate a persisted CRDT document.
-	const hashInput: string = JSON.stringify(
-		Object.fromEntries(
-			[ ...syncedProperties ].map( key => [ key, getRawStringValue( record, key ) ] )
-		)
-	);
+	const hashInput: string = JSON.stringify( record, Object.keys( record ).sort() );
 
 	return await generateHash( hashInput, 'SHA-256' );
 }

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -22,6 +22,7 @@ declare module '@wordpress/sync' {
 
 	// Only include what we actually use from SyncConfig.
 	interface SyncConfig {
+		getInitialObjectData: ( rawRecord: ObjectData ) => ObjectData;
 		getObjectId: ( data: ObjectData ) => ObjectID;
 		objectType: ObjectType;
 		supports?: {
@@ -54,21 +55,19 @@ declare module '@wordpress/sync' {
 		public constructor( connectionCreators: ConnectDoc[] ): void;
 		public bootstrap(
 			syncConfig: SyncConfig,
-			record: ObjectData,
+			rawRecord: ObjectData,
 			handlers: RecordHandlers
 		): Promise< void >;
 
 		public createEntityMeta(
 			syncConfig: SyncConfig,
-			record: ObjectData,
-			changes: Partial< ObjectData >
+			rawRecord: ObjectData
 		): Promise< Record< string, any > >;
 
 		protected getEntityId( type: ObjectType, id: ObjectID ): EntityID;
 		protected getPersistedCRDTDoc(
 			syncConfig: SyncConfig,
-			record: ObjectData,
-			expectedVersion: number
+			rawRecord: ObjectData
 		): Promise< CRDTDoc | null >;
 	}
 }


### PR DESCRIPTION
Persisted CRDT invalidation was broken due to some bad assumptions about "record" vs "object data." The primary issue is the hash was being computed with a record that included `blocks`. Since the blocks are parsed on each initial page load (via `SyncConfig#getInitialObjectData`), they will always have different client IDs and the hashes will mismatch.

We need some custom logic to drop blocks and use `content` instead. As noted in the comments, this should more ideally be controlled by the entity's `SyncConfig`, which could provide the hash implementation directly. However, for now, we want to keep the CRDT persistence implementation in this plugin and outside Gutenberg, along with our choice of hashing mechanisms. 

Minor: We were also not sorting the keys before passing to `JSON.stringify` which might also have led to bad invalidation in edge cases.

We are also dropping the CRDT version check, since that is better implemented by the upstream `SyncProvider`, probably with assistance from the `SyncConfig`. Action must be taken to migrate between versions, and this plugin will not have enough information to conduct that migration. 

In an ideal world, we would have generic types that would help us distinguish between a "raw record" and syncable "object data." For now, we will rename the variables as a primitive signal to help avoid these bad assumptions in the future.