### PR TITLE
Fix revision restoration

### DIFF
--- a/inc/Editor/CrdtPersistence.php
+++ b/inc/Editor/CrdtPersistence.php
@@ -4,7 +4,6 @@ namespace VIPRealTimeCollaboration\Editor;
 
 use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use function add_action;
-use function post_type_supports;
 use function register_meta;
 
 defined( 'ABSPATH' ) || exit();
@@ -30,7 +29,15 @@ final class CrdtPersistence {
 						return user_can( $user_id, 'edit_post', $object_id );
 					},
 					'object_subtype' => $post_type,
-					'revisions_enabled' => post_type_supports( $post_type, 'revisions' ),
+					// IMPORTANT: Revisions must be disabled because we always want to
+					// preserve the latest persisted CRDT document, even when a revision
+					// is restored. This ensures that we can continue to apply updates to
+					// a shared document and peers can simply merge the restored revision
+					// like any other incoming update.
+					//
+					// If we want to persist CRDT documents alongisde revisions in the
+					// future, we should do so in a separate meta key.
+					'revisions_enabled' => false,
 					'show_in_rest' => true,
 					'single' => true,
 					'type' => 'string',

--- a/src/utilities/crdt.ts
+++ b/src/utilities/crdt.ts
@@ -31,9 +31,12 @@ function serializeCrdtDoc( crdtDoc: CRDTDoc ): string {
 	return buffer.toBase64( Y.encodeStateAsUpdateV2( crdtDoc ) );
 }
 
-function deserializeCrdtDoc( serializedCrdtDoc: string ): CRDTDoc {
-	const docMeta = new Map< string, unknown >();
-	const ydoc = new Y.Doc( { meta: docMeta } );
+function deserializeCrdtDoc(
+	serializedCrdtDoc: string,
+	documentMeta: Record< string, unknown > = {}
+): CRDTDoc {
+	const metaMap = new Map< string, unknown >( Object.entries( documentMeta ) );
+	const ydoc = new Y.Doc( { meta: metaMap } );
 	const yupdate = buffer.fromBase64( serializedCrdtDoc );
 	Y.applyUpdateV2( ydoc, yupdate );
 
@@ -44,11 +47,10 @@ function deserializeCrdtDoc( serializedCrdtDoc: string ): CRDTDoc {
 
 /**
  * Type predicate to check the deserialized entity meta value shape. This does
- * not validate the CRDT document itself, but it does validate the content hash.
+ * not validate the CRDT document itself or the content hash.
  */
-function isValidCrdtDocMetaValue(
-	metaValue: unknown,
-	expectedContentHash: string
+function isValidCrdtDocMetaValueShape(
+	metaValue: unknown
 ): metaValue is PersistedCrdtDocMetaValue {
 	if ( 'object' !== typeof metaValue || null === metaValue ) {
 		logger.debug( 'Persisted CRDT document was not found', { metaValue } );
@@ -60,14 +62,8 @@ function isValidCrdtDocMetaValue(
 		return false;
 	}
 
-	if (
-		'string' !== typeof metaValue.contentHash ||
-		metaValue.contentHash !== expectedContentHash
-	) {
-		logger.warn( 'Persisted CRDT document content hash mismatch', {
-			expectedContentHash,
-			metaValue,
-		} );
+	if ( 'string' !== typeof metaValue.contentHash || ! metaValue.contentHash ) {
+		logger.warn( 'Persisted CRDT content hash is empty', { metaValue } );
 		return false;
 	}
 
@@ -134,11 +130,20 @@ export function getPersistedCrdtDocFromEntityMeta(
 
 		const metaValue: unknown = JSON.parse( rawMetaValue );
 
-		if ( ! isValidCrdtDocMetaValue( metaValue, expectedContentHash ) ) {
+		if ( ! isValidCrdtDocMetaValueShape( metaValue ) ) {
 			return null;
 		}
 
-		return deserializeCrdtDoc( metaValue.crdtDoc );
+		const documentMeta: Record< string, unknown > = {};
+
+		// If the meta value content hash does not match the expected hash, mark the
+		// document as invalidated.
+		if ( expectedContentHash !== metaValue.contentHash ) {
+			logger.debug( 'Persisted CRDT content hash mismatch', { expectedContentHash, metaValue } );
+			documentMeta.invalidated = true;
+		}
+
+		return deserializeCrdtDoc( metaValue.crdtDoc, documentMeta );
 	} catch {
 		return null;
 	}

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -29,10 +29,13 @@ export async function getHashForEntityRecord(
 	// We remove the blocks and use the content as a proxy for the blocks, since
 	// blocks are a derived property with unstable identifiers (clientIds).
 	//
+	// We also remove the date since that is updated by the server on save and
+	// this hash must be computed before the record is saved.
+	//
 	// TODO: This should ideally be controlled by the SyncConfig, but since we
 	// don't yet want to introduce hashing utilities to Gutenberg, this logic will
 	// temporarily live here.
-	const { blocks: _discard, ...rest } = objectData;
+	const { blocks: _discard, date: _discard2, ...rest } = objectData;
 	const record = { ...rest, content: getRawStringValue( rawRecord, 'content' ) };
 
 	// Get a string representation of the object data. It should include only the


### PR DESCRIPTION
Three fixes:

- [Disable storing CRDT docs against revisions](https://github.com/Automattic/vip-real-time-collaboration/commit/4f01637a521257e32456a3b3165cd5608bdadb18). We need to preserve the latest persisted CRDT doc so that we can apply our updates against it. Applying our updates against an old persisted doc (i.e., the one from the revision) will result in our updates being ignored by peers (including the WS server).
- [Ignore date when computing content hash](https://github.com/Automattic/vip-real-time-collaboration/commit/5ac2ceda32a10fed8beb71fc2d6a16173dc5bca4). The date is set by the server, so we do not have the correct value when computing the hash prior to saving the meta.
- [Mark documents as invalidated in meta but continue to return them](https://github.com/Automattic/vip-real-time-collaboration/commit/3ddba077b01015978cf4d8d237ac4a8954e86c92). Even if a document has been invalidated (either by an out-of-band update or by restoring a revision), it is still the correct starting point to apply our changes.