### PR TITLE
Combine highlighting and cursor into one setting

### DIFF
--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -20,34 +20,26 @@ import { useSortedAwarenessUsers } from '@/hooks/use-sorted-awareness-users';
 import { isDevelopment } from '@/utilities/config';
 
 export function RTCSettingsPanel() {
-	const {
-		isAvatarsEnabled,
-		isCursorsEnabled,
-		isDebugToolsEnabled,
-		isHighlightsEnabled,
-		isSelfAwarenessEnabled,
-	} = useSelect<
-		SettingsStoreSelectors,
-		{
-			isAvatarsEnabled: boolean;
-			isCursorsEnabled: boolean;
-			isDebugToolsEnabled: boolean;
-			isHighlightsEnabled: boolean;
-			isSelfAwarenessEnabled: boolean;
-		}
-	>( select => {
-		return {
-			isAvatarsEnabled: select( rtcSettingsStore ).isAwarenessAvatarsEnabled(),
-			isCursorsEnabled: select( rtcSettingsStore ).isAwarenessCursorsEnabled(),
-			isDebugToolsEnabled: select( rtcSettingsStore ).isDebugToolsEnabled(),
-			isHighlightsEnabled: select( rtcSettingsStore ).isAwarenessHighlightsEnabled(),
-			isSelfAwarenessEnabled: select( rtcSettingsStore ).isSelfAwarenessEnabled(),
-		};
-	} );
+	const { isAvatarsEnabled, isCursorsEnabled, isDebugToolsEnabled, isSelfAwarenessEnabled } =
+		useSelect<
+			SettingsStoreSelectors,
+			{
+				isAvatarsEnabled: boolean;
+				isCursorsEnabled: boolean;
+				isDebugToolsEnabled: boolean;
+				isSelfAwarenessEnabled: boolean;
+			}
+		>( select => {
+			return {
+				isAvatarsEnabled: select( rtcSettingsStore ).isAwarenessAvatarsEnabled(),
+				isCursorsEnabled: select( rtcSettingsStore ).isAwarenessCursorsEnabled(),
+				isDebugToolsEnabled: select( rtcSettingsStore ).isDebugToolsEnabled(),
+				isSelfAwarenessEnabled: select( rtcSettingsStore ).isSelfAwarenessEnabled(),
+			};
+		} );
 
 	const {
 		setAwarenessAvatarsEnabled,
-		setAwarenessHighlightsEnabled,
 		setAwarenessCursorsEnabled,
 		setDebugToolsEnabled,
 		setSelfAwarenessEnabled,
@@ -60,10 +52,6 @@ export function RTCSettingsPanel() {
 
 	const handleToggleAvatars = ( enabled: boolean ) => {
 		setAwarenessAvatarsEnabled( enabled );
-	};
-
-	const handleToggleHighlights = ( enabled: boolean ) => {
-		setAwarenessHighlightsEnabled( enabled );
 	};
 
 	const handleToggleCursors = ( enabled: boolean ) => {
@@ -90,14 +78,6 @@ export function RTCSettingsPanel() {
 					checked={ isAvatarsEnabled }
 					onChange={ ( enabled: boolean ) => {
 						handleToggleAvatars( enabled );
-					} }
-				/>
-
-				<ToggleControl
-					label="Enable highlights"
-					checked={ isHighlightsEnabled }
-					onChange={ ( enabled: boolean ) => {
-						handleToggleHighlights( enabled );
 					} }
 				/>
 

--- a/src/hooks/use-block-highlighting.ts
+++ b/src/hooks/use-block-highlighting.ts
@@ -19,12 +19,12 @@ export function useBlockHighlighting( blockEditorDocument: Document | null ) {
 		return Array.from( select( awarenessStore ).getActiveUsers().values() );
 	} );
 
-	const { isHighlightsEnabled, isSelfAwarenessEnabled } = useSelect<
+	const { isAwarenessCursorsEnabled, isSelfAwarenessEnabled } = useSelect<
 		SettingsStoreSelectors,
-		{ isHighlightsEnabled: boolean; isSelfAwarenessEnabled: boolean }
+		{ isAwarenessCursorsEnabled: boolean; isSelfAwarenessEnabled: boolean }
 	>( select => {
 		return {
-			isHighlightsEnabled: select( rtcSettingsStore ).isAwarenessHighlightsEnabled(),
+			isAwarenessCursorsEnabled: select( rtcSettingsStore ).isAwarenessCursorsEnabled(),
 			isSelfAwarenessEnabled: select( rtcSettingsStore ).isSelfAwarenessEnabled(),
 		};
 	} );
@@ -68,7 +68,7 @@ export function useBlockHighlighting( blockEditorDocument: Document | null ) {
 			} )
 			.filter( block => block !== null );
 
-		if ( ! isHighlightsEnabled ) {
+		if ( ! isAwarenessCursorsEnabled ) {
 			// If the overlay is disabled, remove all highlights.
 			unhighlightBlocks( Array.from( highlightedBlockIds.current ) );
 			return;
@@ -97,7 +97,7 @@ export function useBlockHighlighting( blockEditorDocument: Document | null ) {
 				highlightedBlockIds.current.add( blockId );
 			}
 		} );
-	}, [ userStates, isHighlightsEnabled, isSelfAwarenessEnabled, blockEditorDocument ] );
+	}, [ userStates, isAwarenessCursorsEnabled, isSelfAwarenessEnabled, blockEditorDocument ] );
 }
 
 const getBlockElementById = (

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -8,7 +8,6 @@ const LOCAL_STORAGE_KEY = 'vip-rtc-settings';
 
 interface SettingsState {
 	isAwarenessAvatarsEnabled: boolean;
-	isAwarenessHighlightsEnabled: boolean;
 	isAwarenessCursorsEnabled: boolean;
 	isDebugToolsEnabled: boolean;
 	isSelfAwarenessEnabled: boolean;
@@ -16,7 +15,6 @@ interface SettingsState {
 
 const DEFAULT_STATE: SettingsState = {
 	isAwarenessAvatarsEnabled: true,
-	isAwarenessHighlightsEnabled: true,
 	isAwarenessCursorsEnabled: true,
 	isDebugToolsEnabled: false,
 	isSelfAwarenessEnabled: false,
@@ -25,10 +23,6 @@ const DEFAULT_STATE: SettingsState = {
 const actions = {
 	setAwarenessAvatarsEnabled: ( enabled: boolean ): SettingsAction => ( {
 		type: 'SET_AWARENESS_AVATARS_ENABLED',
-		payload: enabled,
-	} ),
-	setAwarenessHighlightsEnabled: ( enabled: boolean ): SettingsAction => ( {
-		type: 'SET_AWARENESS_HIGHLIGHTS_ENABLED',
 		payload: enabled,
 	} ),
 	setAwarenessCursorsEnabled: ( enabled: boolean ): SettingsAction => ( {
@@ -54,15 +48,6 @@ const reducer = (
 			const newState = {
 				...state,
 				isAwarenessAvatarsEnabled: action.payload,
-			};
-
-			saveToLocalStorage( LOCAL_STORAGE_KEY, newState );
-			return newState;
-		}
-		case 'SET_AWARENESS_HIGHLIGHTS_ENABLED': {
-			const newState = {
-				...state,
-				isAwarenessHighlightsEnabled: action.payload,
 			};
 
 			saveToLocalStorage( LOCAL_STORAGE_KEY, newState );
@@ -109,10 +94,6 @@ const selectors = {
 		const { isAwarenessCursorsEnabled } = state;
 		return isAwarenessCursorsEnabled;
 	},
-	isAwarenessHighlightsEnabled( state: SettingsState ) {
-		const { isAwarenessHighlightsEnabled } = state;
-		return isAwarenessHighlightsEnabled;
-	},
 	isDebugToolsEnabled( state: SettingsState ) {
 		return isDevelopment() ? state.isDebugToolsEnabled : false;
 	},
@@ -125,7 +106,6 @@ const selectors = {
 type SettingsAction = {
 	type:
 		| 'SET_AWARENESS_AVATARS_ENABLED'
-		| 'SET_AWARENESS_HIGHLIGHTS_ENABLED'
 		| 'SET_AWARENESS_CURSORS_ENABLED'
 		| 'SET_DEBUG_TOOLS_ENABLED'
 		| 'SET_SELF_AWARENESS_ENABLED';
@@ -144,7 +124,6 @@ export type { SettingsState };
 
 export type SettingsStoreActions = {
 	setAwarenessAvatarsEnabled: ( enabled: boolean ) => void;
-	setAwarenessHighlightsEnabled: ( enabled: boolean ) => void;
 	setAwarenessCursorsEnabled: ( enabled: boolean ) => void;
 	setDebugToolsEnabled: ( enabled: boolean ) => void;
 	setSelfAwarenessEnabled: ( enabled: boolean ) => void;
@@ -152,7 +131,6 @@ export type SettingsStoreActions = {
 
 export type SettingsStoreSelectors = {
 	isAwarenessAvatarsEnabled: () => boolean;
-	isAwarenessHighlightsEnabled: () => boolean;
 	isAwarenessCursorsEnabled: () => boolean;
 	isDebugToolsEnabled: () => boolean;
 	isSelfAwarenessEnabled: () => boolean;


### PR DESCRIPTION
### Description

The goal of this is to combine the `Enable cursors` and `Enable highlighting` into one setting - `Enable cursors` to power both the cursor and block highlighting feature. This was one of the issues we talked about in the last sync, but wasn't converted to a linear issue.

I've kept the option as `Enable cursors` internally and externally. I figured its similar to the Google Docs point which is that it's the same thing - cursors everywhere.

Happy to change this up as needed though.

<img width="191" height="155" alt="CleanShot 2025-09-19 at 14 29 36" src="https://github.com/user-attachments/assets/ab20cc51-c5d0-4f77-b0cd-1583aae0f976" />

https://github.com/user-attachments/assets/087e1a96-3b1a-457c-96ec-5454519bce21
