### PR TITLE
Fix the plugin zip command

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:phpcs:fix": "vendor/bin/phpcbf",
     "lint:psalm": "vendor/bin/psalm.phar",
     "packages-update": "wp-scripts packages-update",
-    "plugin-zip": "npm run build && composer install --prefer-dist --optimize-autoloader --no-dev && wp-scripts plugin-zip",
+    "plugin-zip": "npm run build && composer install --prefer-dist --optimize-autoloader --no-dev && wp-scripts plugin-zip --no-root-folder",
     "postinstall": "composer install",
     "release": "./bin/release",
     "start": "wp-scripts start --experimental-modules --stats=minimal",


### PR DESCRIPTION
### Description

This'll ensure that we don't make another folder with the plugin's name in the zip file. So now the release workflow will actually work as expected