### PR TITLE
Remove root dir from plugin zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:phpcs:fix": "vendor/bin/phpcbf",
     "lint:psalm": "vendor/bin/psalm.phar",
     "packages-update": "wp-scripts packages-update",
-    "plugin-zip": "npm run build && composer install --prefer-dist --optimize-autoloader --no-dev && wp-scripts plugin-zip",
+    "plugin-zip": "npm run build && composer install --prefer-dist --optimize-autoloader --no-dev && wp-scripts plugin-zip --no-root-folder",
     "postinstall": "composer install",
     "release": "./bin/release",
     "start": "wp-scripts start --experimental-modules --stats=minimal",


### PR DESCRIPTION
The plugin-zip command generated an extra vip-real-time-collaboration folder within the zip, adding `--no-root-folder` flag when building release zip fixes it (Props to @ingeniumed for suggesting this fix). This aligns with how the zip is structured for [remote-data-blocks](https://github.com/Automattic/remote-data-blocks).

## Testing
- Checkout the `trunk` and run `npm run plugin-zip` and verify the zip structure with `unzip -l vip-real-time-collaboration.zip`. That outputs something like - 

    ```sh
    unzip -l vip-real-time-collaboration.zip
    Archive:  vip-real-time-collaboration.zip
      Length      Date    Time    Name
    ---------  ---------- -----   ----
        4474  09-29-2025 09:50   vip-real-time-collaboration/build/index-rtl.css
         304  09-29-2025 09:50   vip-real-time-collaboration/build/index.asset.php
        4473  09-26-2025 16:21   vip-real-time-collaboration/build/index.css
        ...rest of the files
    ```

- Checkout this branch, run `npm run plugin-zip` and verify the zip structure with `unzip -l vip-real-time-collaboration.zip`. That outputs something like - 

    ```sh
    unzip -l vip-real-time-collaboration.zip
    Archive:  vip-real-time-collaboration.zip
      Length      Date    Time    Name
    ---------  ---------- -----   ----
        4474  09-29-2025 09:50   build/index-rtl.css
         304  09-29-2025 09:50   build/index.asset.php
        4473  09-26-2025 16:21   build/index.css
        ...rest of the files
    ```