### PR TITLE
Add flags to json_encode

### DIFF
--- a/inc/Assets/Assets.php
+++ b/inc/Assets/Assets.php
@@ -60,7 +60,7 @@ final class Assets {
 			'rtcPostMetaKey' => CrdtPersistence::POST_META_KEY,
 			'wsUrl' => $vip_rtc_ws_url,
 			'blogId' => get_current_blog_id(),
-		] );
+		], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 
 		/** @psalm-suppress DocblockTypeContradiction */ // wp_json_encode() can return an empty string.
 		if ( ! is_string( $script_data ) || '' === $script_data ) {


### PR DESCRIPTION
Add flags to json_encode to protect against unsafe inline scripts. This is more or less trusted data, but is best practice.

Details: https://sirre.al/2025/08/06/safe-json-in-script-tags-how-not-to-break-a-site/