### PR TITLE
Fix fatal error when experiments option is set to empty string

### DIFF
--- a/inc/Compatibility/Compatibility.php
+++ b/inc/Compatibility/Compatibility.php
@@ -47,9 +47,7 @@ final class Compatibility {
 			$experiments = [];
 		}
 
-		if ( array_key_exists( 'gutenberg-sync-collaboration', $experiments ) ) {
-			unset( $experiments['gutenberg-sync-collaboration'] );
-		}
+		unset( $experiments['gutenberg-sync-collaboration'] );
 
 		// Do not enable on Site Editor.
 		if ( 'site-editor.php' === $pagenow ) {

--- a/inc/Compatibility/Compatibility.php
+++ b/inc/Compatibility/Compatibility.php
@@ -45,8 +45,12 @@ final class Compatibility {
 
 		// Do not enable on Site Editor.
 		if ( 'site-editor.php' === $pagenow ) {
-			if ( is_array( $experiments ) && array_key_exists( 'gutenberg-sync-collaboration', $experiments ) ) {
-				unset( $experiments['gutenberg-sync-collaboration'] );
+			if ( is_array( $experiments ) ) {
+				if ( array_key_exists( 'gutenberg-sync-collaboration', $experiments ) ) {
+					unset( $experiments['gutenberg-sync-collaboration'] );
+				}
+
+				return $experiments;
 			}
 
 			return [];

--- a/inc/Compatibility/Compatibility.php
+++ b/inc/Compatibility/Compatibility.php
@@ -40,12 +40,16 @@ final class Compatibility {
 	 *
 	 * @psalm-suppress PossiblyUnusedReturnValue Psalm does not detect usage via add_filter.
 	 */
-	public function enable_sync_collaboration_experiment( array|false $experiments ): array|false {
+	public function enable_sync_collaboration_experiment( mixed $experiments ): array|false {
 		global $pagenow;
 
 		// Do not enable on Site Editor.
 		if ( 'site-editor.php' === $pagenow ) {
-			return $experiments;
+			if ( is_array( $experiments ) && array_key_exists( 'gutenberg-sync-collaboration', $experiments ) ) {
+				unset( $experiments['gutenberg-sync-collaboration'] );
+			}
+
+			return [];
 		}
 
 		if ( ! is_array( $experiments ) ) {

--- a/inc/Compatibility/Compatibility.php
+++ b/inc/Compatibility/Compatibility.php
@@ -40,26 +40,20 @@ final class Compatibility {
 	 *
 	 * @psalm-suppress PossiblyUnusedReturnValue Psalm does not detect usage via add_filter.
 	 */
-	public function enable_sync_collaboration_experiment( mixed $experiments ): array|false {
+	public function enable_sync_collaboration_experiment( mixed $experiments ): array {
 		global $pagenow;
+
+		if ( ! is_array( $experiments ) ) {
+			$experiments = [];
+		}
+
+		if ( array_key_exists( 'gutenberg-sync-collaboration', $experiments ) ) {
+			unset( $experiments['gutenberg-sync-collaboration'] );
+		}
 
 		// Do not enable on Site Editor.
 		if ( 'site-editor.php' === $pagenow ) {
-			if ( is_array( $experiments ) ) {
-				if ( array_key_exists( 'gutenberg-sync-collaboration', $experiments ) ) {
-					unset( $experiments['gutenberg-sync-collaboration'] );
-				}
-
-				return $experiments;
-			}
-
-			return [];
-		}
-
-		if ( ! is_array( $experiments ) ) {
-			return [
-				'gutenberg-sync-collaboration' => true,
-			];
+			return $experiments;
 		}
 
 		$experiments['gutenberg-sync-collaboration'] = true;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -104,6 +104,10 @@
 		<exclude-pattern>/tests/*</exclude-pattern>
 	</rule>
 
+	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
 		<exclude-pattern>/inc/*</exclude-pattern>
 		<exclude-pattern>/tests/*</exclude-pattern>

--- a/tests/Integration/CompatibilityTest.php
+++ b/tests/Integration/CompatibilityTest.php
@@ -5,12 +5,22 @@ namespace VIPRealTimeCollaboration\Tests\Integration;
 use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use VIPRealTimeCollaboration\Tests\Traits\ReflectionUtils;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
+use function activate_plugin;
+use function deactivate_plugins;
+use function delete_option;
+use function update_option;
 
 /**
  * Integration Tests for the Compatibility class.
  */
 final class CompatibilityTest extends TestCase {
 	use ReflectionUtils;
+
+	public function tearDown(): void {
+		delete_option( 'gutenberg-experiments' );
+
+		parent::tearDown();
+	}
 
 	/**
 	 * Verifies that should_plugin_load() works as expected.
@@ -32,5 +42,88 @@ final class CompatibilityTest extends TestCase {
 		activate_plugin( 'gutenberg/gutenberg.php' );
 		self::assertTrue( $is_gutenberg_plugin_active->invoke( null ), 'is_gutenberg_plugin_active should be true' );
 		self::assertTrue( $should_plugin_load->invoke( null ), 'should_plugin_load() should be true' );
+	}
+
+	/**
+	 * Verifies that enable_sync_collaboration_experiment() handles empty string option value.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::enable_sync_collaboration_experiment
+	 */
+	public function test_enable_sync_collaboration_experiment_when_option_does_not_exist(): void {
+		new Compatibility();
+
+		$result = get_option( 'gutenberg-experiments' );
+
+		self::assertIsArray( $result, 'Filter should return an array when given an empty string' );
+		self::assertArrayHasKey( 'gutenberg-sync-collaboration', $result, 'Result should contain the sync collaboration experiment' );
+		self::assertTrue( $result['gutenberg-sync-collaboration'], 'Sync collaboration experiment should be enabled' );
+	}
+
+	public function option_values_provider(): array {
+		return [
+			'empty string' => [ '' ],
+			'non-empty string' => [ 'foo' ],
+			'null' => [ null ],
+			'false' => [ false ],
+			'empty_array' => [ [] ],
+			'array_without_experiment' => [ [ 'some-other-experiment' => true ] ],
+			'array_with_experiment_disabled' => [ [ 'gutenberg-sync-collaboration' => false ] ],
+			'array_with_experiment_enabled' => [ [ 'gutenberg-sync-collaboration' => true ] ],
+		];
+	}
+
+	/**
+	 * Verifies that enable_sync_collaboration_experiment() handles various option
+	 * values via a data provider.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::enable_sync_collaboration_experiment
+	 * @dataProvider option_values_provider
+	 * @global $pagenow
+	 *
+	 * @param mixed $option_value The option value to set before testing.
+	 *
+	 * @psalm-suppress UnusedParam Psalm does not detect usage via dataProvider.
+	 */
+	public function test_enable_sync_collaboration_experiment_when_option_is_set_to( mixed $option_value ): void {
+		update_option( 'gutenberg-experiments', $option_value );
+
+		new Compatibility();
+
+		$result = get_option( 'gutenberg-experiments' );
+
+		self::assertIsArray( $result, 'Filter should return an array when given an empty string' );
+		self::assertArrayHasKey( 'gutenberg-sync-collaboration', $result, 'Result should contain the sync collaboration experiment' );
+		self::assertTrue( $result['gutenberg-sync-collaboration'], 'Sync collaboration experiment should be enabled' );
+	}
+
+	/**
+	 * Verifies that enable_sync_collaboration_experiment() handles various option
+	 * values via a data provider.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::enable_sync_collaboration_experiment
+	 * @dataProvider option_values_provider
+	 * @global $pagenow
+	 *
+	 * @param mixed $option_value The option value to set before testing.
+	 *
+	 * @psalm-suppress UnusedParam Psalm does not detect usage via dataProvider.
+	 */
+	public function test_disables_sync_collaboration_experiment_on_site_editor( mixed $option_value ): void {
+		global $pagenow;
+
+		// Simulate Site Editor page.
+		$previous_pagenow = $pagenow;
+		$pagenow = 'site-editor.php';
+
+		update_option( 'gutenberg-experiments', $option_value );
+
+		new Compatibility();
+
+		$result = get_option( 'gutenberg-experiments' );
+
+		self::assertIsArray( $result, 'Filter should return an array when given an empty string' );
+		self::assertArrayNotHasKey( 'gutenberg-sync-collaboration', $result, 'Result should not contain the sync collaboration experiment' );
+
+		$pagenow = $previous_pagenow;
 	}
 }

--- a/tests/Integration/CompatibilityTest.php
+++ b/tests/Integration/CompatibilityTest.php
@@ -98,7 +98,7 @@ final class CompatibilityTest extends TestCase {
 
 	/**
 	 * Verifies that enable_sync_collaboration_experiment() handles various option
-	 * values via a data provider.
+	 * values on the site editor page via a data provider.
 	 *
 	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::enable_sync_collaboration_experiment
 	 * @dataProvider option_values_provider
@@ -123,6 +123,35 @@ final class CompatibilityTest extends TestCase {
 
 		self::assertIsArray( $result, 'Filter should return an array when given an empty string' );
 		self::assertArrayNotHasKey( 'gutenberg-sync-collaboration', $result, 'Result should not contain the sync collaboration experiment' );
+
+		$pagenow = $previous_pagenow;
+	}
+
+	/**
+	 * Verifies that enable_sync_collaboration_experiment() only diables the sync
+	 * collaboration experiment on the site editor page, leaving other experiments
+	 * intact.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::enable_sync_collaboration_experiment
+	 * @global $pagenow
+	 */
+	public function test_disables_only_sync_collaboration_experiment_on_site_editor(): void {
+		global $pagenow;
+
+		// Simulate Site Editor page.
+		$previous_pagenow = $pagenow;
+		$pagenow = 'site-editor.php';
+
+		update_option( 'gutenberg-experiments', [ 'foo' => true ] );
+
+		new Compatibility();
+
+		$result = get_option( 'gutenberg-experiments' );
+
+		self::assertIsArray( $result, 'Filter should return an array when given an empty string' );
+		self::assertArrayNotHasKey( 'gutenberg-sync-collaboration', $result, 'Result should not contain the sync collaboration experiment' );
+		self::assertArrayHasKey( 'foo', $result, 'Result should contain the test experiment' );
+		self::assertTrue( $result['foo'], 'Test experiment should be enabled' );
 
 		$pagenow = $previous_pagenow;
 	}


### PR DESCRIPTION
Fix fatal error (due to type hint) when experiments option is set to empty string. Add integration tests to cover possible option values.