### PR TITLE
Implement removal of sync settings field in Gutenberg

### DIFF
--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -66,8 +66,9 @@ final class Overrides {
 	 *
 	 * This is to prevent users from disabling the collaborative editing feature,
 	 * which is controlled within the plugin.
+	 * @psalm-suppress MixedArrayAccess
 	 */
-	public function remove_sync_setttings_field() {
+	public function remove_sync_setttings_field(): void {
 		global $wp_settings_fields;
 		if ( isset( $wp_settings_fields['gutenberg-experiments']['gutenberg_experiments_section']['gutenberg-sync-collaboration'] ) ) {
 			unset( $wp_settings_fields['gutenberg-experiments']['gutenberg_experiments_section']['gutenberg-sync-collaboration'] );

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -26,6 +26,8 @@ final class Overrides {
 
 		// Ensure that the _edit_lock meta key is never returned, effectively disabling the post lock functionality just for revisions.php.
 		add_filter( 'get_post_metadata', [ $this, 'filter_post_meta' ], 10, 3 );
+
+		add_action( 'admin_init', [ $this, 'remove_sync_setttings_field' ], 999 );
 	}
 
 	/**
@@ -57,5 +59,19 @@ final class Overrides {
 
 		// Otherwise, return the original value.
 		return $value;
+	}
+
+	/**
+	 * Remove the sync collaboration settings field from the Gutenberg experiments page.
+	 *
+	 * This is to prevent users from disabling the collaborative editing feature,
+	 * which is controlled within the plugin.
+	 *
+	 * @return void
+	 */
+	public function remove_sync_setttings_field(): void {
+		global $wp_settings_fields;
+
+		unset( $wp_settings_fields['gutenberg-experiments']['gutenberg_experiments_section']['gutenberg-sync-collaboration'] );
 	}
 }

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -66,12 +66,11 @@ final class Overrides {
 	 *
 	 * This is to prevent users from disabling the collaborative editing feature,
 	 * which is controlled within the plugin.
-	 *
-	 * @return void
 	 */
-	public function remove_sync_setttings_field(): void {
+	public function remove_sync_setttings_field() {
 		global $wp_settings_fields;
-
-		unset( $wp_settings_fields['gutenberg-experiments']['gutenberg_experiments_section']['gutenberg-sync-collaboration'] );
+		if ( isset( $wp_settings_fields['gutenberg-experiments']['gutenberg_experiments_section']['gutenberg-sync-collaboration'] ) ) {
+			unset( $wp_settings_fields['gutenberg-experiments']['gutenberg_experiments_section']['gutenberg-sync-collaboration'] );
+		}
 	}
 }


### PR DESCRIPTION
Remove the sync collaboration settings field from the Gutenberg experiments page to avoid users thinking it can be disabled.

Follow-up to: #60