### PR TITLE
adding div for Pendo targeting

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,6 +19,12 @@ Please see [SECURITY.md](SECURITY.md).
 
 ### Running the development environment
 
+Install dependences:
+
+```sh
+npm install
+```
+
 Start the development environment:
 
 ```sh

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -149,6 +149,7 @@ export function RTCSettingsPanel() {
 						</FlexItem>
 					) ) }
 				</Flex>
+				<div className="vip-telemetry-target"></div>
 			</PluginDocumentSettingPanel>
 		</>
 	);


### PR DESCRIPTION
In order to properly insert a user guide, we need an empty div to target.

I also added the only other command I ran to get up and running.