### PR TITLE
Add a PHP and WP version check

### DIFF
--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -28,6 +28,37 @@ if ( defined( 'VIP_REAL_TIME_COLLABORATION__LOADED' ) ) {
 }
 
 define( 'VIP_REAL_TIME_COLLABORATION__LOADED', true );
+
+/** @psalm-suppress PossiblyFalseArgument */
+if ( version_compare( phpversion(), '8.2', '<' ) ) {
+	add_action( 'admin_notices', function (): void {
+		wp_admin_notice(
+			__(
+				'The VIP Real-Time Collaboration plugin requires PHP 8.2+. The VIP Real-Time Collaboration plugin has been disabled.',
+				'vip_real_time_collaboration'
+			),
+			[ 'type' => 'error' ]
+		);
+	}, 10, 0 );
+	return;
+}
+
+/** @psalm-suppress InvalidGlobal */
+global $wp_version;
+/** @psalm-suppress MixedArgument */
+if ( version_compare( $wp_version, '6.7', '<' ) ) {
+	add_action( 'admin_notices', function (): void {
+		wp_admin_notice(
+			__(
+				'The VIP Real-Time Collaboration plugin requires WordPress 6.7+. The VIP Real-Time Collaboration plugin has been disabled.',
+				'vip_real_time_collaboration'
+			),
+			[ 'type' => 'error' ]
+		);
+	}, 10, 0 );
+	return;
+}
+
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_ROOT', __FILE__ );
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_DIRECTORY', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION', '0.1.3' );

--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -27,46 +27,11 @@ if ( defined( 'VIP_REAL_TIME_COLLABORATION__LOADED' ) ) {
 	return;
 }
 
+if ( ! vip_real_time_collaboration_pre_init() ) {
+	return;
+}
+
 define( 'VIP_REAL_TIME_COLLABORATION__LOADED', true );
-
-$php_version = phpversion();
-if ( is_string( $php_version ) && version_compare( $php_version, '8.2', '<' ) ) {
-	add_action( 'admin_notices', function (): void {
-		wp_admin_notice(
-			__(
-				'The VIP Real-Time Collaboration plugin requires PHP 8.2+. The VIP Real-Time Collaboration plugin has been disabled.',
-				'vip_real_time_collaboration'
-			),
-			[ 'type' => 'error' ]
-		);
-	}, 10, 0 );
-	return;
-}
-
-/** @psalm-suppress InvalidGlobal */
-global $wp_version;
-
-// Account for plugins overriding the $wp_version global.
-// Taken from the implementation of 'wp_get_wp_version()', which is 6.7 only.
-/** @psalm-suppress MissingFile */
-// This is a built-in WordPress file, so we can ignore the warning here.
-if ( ! isset( $wp_version ) ) {
-	require ABSPATH . WPINC . '/version.php';
-}
-
-if ( is_string( $wp_version ) && version_compare( $wp_version, '6.7', '<' ) ) {
-	add_action( 'admin_notices', function (): void {
-		wp_admin_notice(
-			__(
-				'The VIP Real-Time Collaboration plugin requires WordPress 6.7+. The VIP Real-Time Collaboration plugin has been disabled.',
-				'vip_real_time_collaboration'
-			),
-			[ 'type' => 'error' ]
-		);
-	}, 10, 0 );
-	return;
-}
-
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_ROOT', __FILE__ );
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_DIRECTORY', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION', '0.1.3' );
@@ -99,3 +64,48 @@ add_action( 'plugins_loaded', static function (): void {
 	// Fire action to indicate that the plugin has loaded.
 	do_action( 'vip_real_time_collaboration_loaded' );
 }, 10, 0 );
+
+/**
+ * Verify that we can initialize the VIP Real-Time Collaboration plugin.
+ *
+ * @global string $wp_version The WordPress version string.
+ *
+ * @return bool true if the plugin can load, false otherwise.
+ */
+function vip_real_time_collaboration_pre_init(): bool {
+	$php_version = phpversion();
+	if ( is_string( $php_version ) && version_compare( $php_version, '8.2', '<' ) ) {
+		add_action( 'admin_notices', function (): void {
+			wp_admin_notice(
+				__(
+					'The VIP Real-Time Collaboration plugin requires PHP 8.2+. The VIP Real-Time Collaboration plugin has been disabled.',
+					'vip_real_time_collaboration'
+				),
+				[ 'type' => 'error' ]
+			);
+		}, 10, 0 );
+		return false;
+	}
+
+	global $wp_version;
+
+	// Account for plugins overriding the $wp_version global, look at Gutenberg.php for reference.
+	/** @psalm-suppress MissingFile */
+	// This is a built-in WordPress file, so we can ignore the warning here.
+	require ABSPATH . WPINC . '/version.php';
+
+	if ( version_compare( $wp_version, '6.7', '<' ) ) {
+		add_action( 'admin_notices', function (): void {
+			wp_admin_notice(
+				__(
+					'The VIP Real-Time Collaboration plugin requires WordPress 6.7+. The VIP Real-Time Collaboration plugin has been disabled.',
+					'vip_real_time_collaboration'
+				),
+				[ 'type' => 'error' ]
+			);
+		}, 10, 0 );
+		return false;
+	}
+
+	return true;
+}

--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -29,8 +29,8 @@ if ( defined( 'VIP_REAL_TIME_COLLABORATION__LOADED' ) ) {
 
 define( 'VIP_REAL_TIME_COLLABORATION__LOADED', true );
 
-/** @psalm-suppress PossiblyFalseArgument */
-if ( version_compare( phpversion(), '8.2', '<' ) ) {
+$php_version = phpversion();
+if ( is_string( $php_version ) && version_compare( $php_version, '8.2', '<' ) ) {
 	add_action( 'admin_notices', function (): void {
 		wp_admin_notice(
 			__(
@@ -45,8 +45,16 @@ if ( version_compare( phpversion(), '8.2', '<' ) ) {
 
 /** @psalm-suppress InvalidGlobal */
 global $wp_version;
-/** @psalm-suppress MixedArgument */
-if ( version_compare( $wp_version, '6.7', '<' ) ) {
+
+// Account for plugins overriding the $wp_version global.
+// Taken from the implementation of 'wp_get_wp_version()', which is 6.7 only.
+/** @psalm-suppress MissingFile */
+// This is a built-in WordPress file, so we can ignore the warning here.
+if ( ! isset( $wp_version ) ) {
+	require ABSPATH . WPINC . '/version.php';
+}
+
+if ( is_string( $wp_version ) && version_compare( $wp_version, '6.7', '<' ) ) {
 	add_action( 'admin_notices', function (): void {
 		wp_admin_notice(
 			__(

--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -89,10 +89,10 @@ function vip_real_time_collaboration_pre_init(): bool {
 
 	global $wp_version;
 
-	// Account for plugins overriding the $wp_version global, look at Gutenberg.php for reference.
+	// Account for plugins overriding the $wp_version global, look at gutenberg.php for reference.
 	/** @psalm-suppress MissingFile */
 	// This is a built-in WordPress file, so we can ignore the warning here.
-	require ABSPATH . WPINC . '/version.php';
+	include ABSPATH . WPINC . '/version.php';
 
 	if ( version_compare( $wp_version, '6.7', '<' ) ) {
 		add_action( 'admin_notices', function (): void {


### PR DESCRIPTION
### Description

We don't currently have any checks to enforce the WP/PHP requirements that we have in place, which is of 8.2 and 6.7. This change will implement that feature, such that an admin notice will be visible informing a user about an error.

There are two key differences compared to how the Governance plugin did this:

- Use `wp_admin_notice` as our minimum version is 6.7 not 6.4. We could go for the older way, but I think it's fine imo.
- WP's version.php is required to ensure that if plugins override the wp_version then it'll still work.

wp_get_wp_version cannot be used btw, as that's 6.7+ which ironically would not work for this problem.

### Testing

- Either load an earlier version of WP/PHP and load the plugin
- Or, flip the signs and test it on a newer WP/PHP

<img width="1699" height="399" alt="CleanShot 2025-10-13 at 15 15 08" src="https://github.com/user-attachments/assets/95beead8-679a-4a3f-84f7-a4d07a15e289" />