### PR TITLE
Move <Avatars> to the header

### DIFF
--- a/src/components/avatars.tsx
+++ b/src/components/avatars.tsx
@@ -24,22 +24,17 @@ export function Avatars() {
 	const remainingUsers = activeUsers.slice( 3 );
 	const remainingUsersText = remainingUsers.map( userState => userState.name ).join( ', ' );
 
-	return (
-		<div className="vip-real-time-collaboration-avatars-container">
-			<div className="vip-real-time-collaboration-avatars">
-				{ visibleUsers.map( userState => (
-					<Avatar key={ userState.clientId } userState={ userState } showUserColorBorder={ true } />
-				) ) }
+	return visibleUsers.length > 1 ? (
+		<>
+			{ visibleUsers.map( userState => (
+				<Avatar key={ userState.clientId } userState={ userState } showUserColorBorder={ false } />
+			) ) }
 
-				{ remainingUsers.length > 0 && (
-					<div
-						className="vip-real-time-collaboration-avatar-remaining"
-						title={ remainingUsersText }
-					>
-						+{ remainingUsers.length }
-					</div>
-				) }
-			</div>
-		</div>
-	);
+			{ remainingUsers.length > 0 && (
+				<div className="vip-real-time-collaboration-avatar-remaining" title={ remainingUsersText }>
+					+{ remainingUsers.length }
+				</div>
+			) }
+		</>
+	) : null;
 }

--- a/src/components/rtc-overlay.scss
+++ b/src/components/rtc-overlay.scss
@@ -1,56 +1,38 @@
-.vip-real-time-collaboration-avatars-container {
-	position: sticky;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
+.vip-real-time-collaboration-avatar {
+	margin-left: -16px;
+	flex-shrink: 0;
+
+	&:nth-child(1) {
+		margin-left: 0;
+		z-index: 3;
+	}
+
+	&:nth-child(2) {
+		z-index: 2
+	}
+
+	&:nth-child(3) {
+		z-index: 1;
+	}
 }
 
-.vip-real-time-collaboration-avatars {
-	background-color: #fff;
-	border-radius: 16px;
-	border: 1px solid #ddd;
-	padding: 4px 8px;
-	position: absolute;
-	top: 10px;
-	right: 8px;
-	pointer-events: auto;
-
-	display: flex;
-	align-items: center;
-
-	.vip-real-time-collaboration-avatar {
-		margin-left: -10px;
-
-		&:nth-child(1) {
-			margin-left: 0;
-			z-index: 3;
-		}
-
-		&:nth-child(2) {
-			z-index: 2;
-		}
-
-		&:nth-child(3) {
-			z-index: 1;
-		}
-	}
-
-	.vip-real-time-collaboration-avatar-remaining {
-		margin: 0 6px 0 4px;
-	}
+.vip-real-time-collaboration-avatar-remaining {
+	margin-right: 6px;
 }
 
 .vip-real-time-collaboration-avatar {
 	width: 28px;
 	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
 	img {
 		width: 24px;
 		height: 24px;
-		border-radius: 50%;
+		border-radius: 8px;
 		object-fit: cover;
-		border: 2px solid #fff;
+		border: 2px solid #f0f0f0;
 
 		/* Fallback for images that haven't loaded yet */
 		font-size: 0; // Hide alt text while the image loads.

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -7,7 +7,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { PluginDocumentSettingPanel, EditorsPresence } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 import { Avatar } from './avatar';
@@ -70,9 +70,9 @@ export function RTCSettingsPanel() {
 	return (
 		<>
 			{ isAvatarsEnabled && (
-				<BlockCanvasCover.Fill>
+				<EditorsPresence>
 					<Avatars />
-				</BlockCanvasCover.Fill>
+				</EditorsPresence>
 			) }
 			<BlockCanvasCover.Fill>
 				{ ( { containerRef }: { containerRef: React.MutableRefObject< HTMLElement | null > } ) => (

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -6,4 +6,6 @@ declare module '@wordpress/editor' {
 		getCurrentPostType(): string | null;
 		getEditedPostContent(): string | null;
 	}
+
+	const EditorsPresence: React.FC< React.PropsWithChildren >;
 }


### PR DESCRIPTION
* Requires https://github.com/Automattic/gutenberg/pull/46

More closely aligns with the latest design work by moving the avatars out of the editor area and into the header.

Refs VIP-2077