### PR TITLE
Hide lock modal based on user access to feature

### DIFF
--- a/inc/Assets/Assets.php
+++ b/inc/Assets/Assets.php
@@ -4,11 +4,13 @@ namespace VIPRealTimeCollaboration\Assets;
 
 defined( 'ABSPATH' ) || exit();
 
+use VIPRealTimeCollaboration\Auth\SyncPermissions;
 use VIPRealTimeCollaboration\Editor\CrdtPersistence;
 use function add_action;
 use function plugins_url;
 use function wp_add_inline_script;
 use function wp_die;
+use function wp_get_current_user;
 use function wp_enqueue_script;
 
 /**
@@ -21,6 +23,8 @@ final class Assets {
 	}
 
 	public function load_assets(): void {
+		global $post;
+
 		$vip_rtc_ws_url = null;
 
 		// Error checking for the WebSocket URL is already done in the main plugin file.
@@ -55,11 +59,13 @@ final class Assets {
 			[ 'in_footer' => false ]
 		);
 
+		$current_user = wp_get_current_user();
 		$script_data = wp_json_encode( [
+			'blogId' => get_current_blog_id(),
 			'debug' => [],
 			'rtcPostMetaKey' => CrdtPersistence::POST_META_KEY,
+			'syncEnabled' => $current_user->has_cap( SyncPermissions::CAP_NAME, $post->ID ?? null ),
 			'wsUrl' => $vip_rtc_ws_url,
-			'blogId' => get_current_blog_id(),
 		], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 
 		/** @psalm-suppress DocblockTypeContradiction */ // wp_json_encode() can return an empty string.
@@ -69,7 +75,7 @@ final class Assets {
 
 		wp_add_inline_script(
 			'vip-real-time-collaboration',
-			"var VIP_RTC = $script_data;",
+			"var VIP_RTC = $script_data;window.__experimentalEnableSync = VIP_RTC.syncEnabled;",
 			'before'
 		);
 	}

--- a/inc/Assets/Assets.php
+++ b/inc/Assets/Assets.php
@@ -6,6 +6,7 @@ defined( 'ABSPATH' ) || exit();
 
 use VIPRealTimeCollaboration\Auth\SyncPermissions;
 use VIPRealTimeCollaboration\Editor\CrdtPersistence;
+use WP_Post;
 use function add_action;
 use function plugins_url;
 use function wp_add_inline_script;
@@ -64,7 +65,7 @@ final class Assets {
 			'blogId' => get_current_blog_id(),
 			'debug' => [],
 			'rtcPostMetaKey' => CrdtPersistence::POST_META_KEY,
-			'syncEnabled' => $current_user->has_cap( SyncPermissions::CAP_NAME, $post->ID ?? null ),
+			'syncEnabled' => $post instanceof WP_Post ? $current_user->has_cap( SyncPermissions::CAP_NAME, $post->ID ) : null,
 			'wsUrl' => $vip_rtc_ws_url,
 		], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 

--- a/inc/Auth/SyncPermissions.php
+++ b/inc/Auth/SyncPermissions.php
@@ -10,6 +10,8 @@ defined( 'ABSPATH' ) || exit;
  * Handles permission checking for sync objects using custom sync capabilities
  */
 final class SyncPermissions {
+	const CAP_NAME = 'edit_with_others';
+
 	/**
 	 * Initialize custom sync capabilities.
 	 * Sets up meta capability mapping and role capabilities.
@@ -110,7 +112,7 @@ final class SyncPermissions {
 		// Check sync_post capability (will be mapped to edit_post via map_meta_cap)
 		/** @var bool|WP_Error $can_sync_post */
 		$can_sync_post = true;
-		if ( ! current_user_can( 'sync_post', $parsed_post_id ) ) {
+		if ( ! current_user_can( self::CAP_NAME, $parsed_post_id ) ) {
 			$can_sync_post = new WP_Error(
 				'insufficient_sync_permissions',
 				__( 'You do not have permission to sync this content', 'vip-real-time-collaboration' )
@@ -194,8 +196,8 @@ final class SyncPermissions {
 
 		foreach ( $roles_to_update as $role_name ) {
 			$role = get_role( $role_name );
-			if ( $role && ! $role->has_cap( 'sync_post' ) ) {
-				$role->add_cap( 'sync_post' );
+			if ( $role && ! $role->has_cap( self::CAP_NAME ) ) {
+				$role->add_cap( self::CAP_NAME );
 			}
 		}
 	}

--- a/inc/Editor/PostLock.php
+++ b/inc/Editor/PostLock.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace VIPRealTimeCollaboration\Editor;
+
+use VIPRealTimeCollaboration\Auth\SyncPermissions;
+use WP_Post;
+use WP_User;
+use function add_filter;
+use function get_user_by;
+use function wp_check_post_lock;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Provides additional context to the built-in post locking functionality to
+ * ensure compatibility with real-time collaboration.
+ */
+final class PostLock {
+	public function __construct() {
+		add_filter( 'block_editor_settings_all', [ $this, 'enhance_post_lock_user' ], 50, 1 );
+		add_filter( 'heartbeat_received', [ $this, 'enhance_heartbeat_response' ], 500, 2 );
+	}
+
+	/**
+	 * Add a `syncEnabled` property on the block editor post lock settings.
+	 *
+	 * @param array{
+	 *   postLock: array{
+	 *     isLocked: bool,
+	 *     user: array{
+	 *       syncEnabled: bool,
+	 *    },
+	 *  },
+	 * } $settings Block editor settings.
+	 */
+	public function enhance_post_lock_user( array $settings ): array {
+		global $post;
+
+		if ( $post instanceof WP_Post && true === ( $settings['postLock']['isLocked'] ?? false ) && isset( $settings['postLock']['user'] ) ) {
+			$sync_enabled = false;
+
+			// Get the lock owner.
+			$lock_owner_id = wp_check_post_lock( $post );
+			if ( $lock_owner_id > 0 ) {
+				$lock_owner = get_user_by( 'id', $lock_owner_id );
+
+				if ( $lock_owner instanceof WP_User ) {
+					$sync_enabled = $lock_owner->has_cap( SyncPermissions::CAP_NAME, $post->ID );
+				}
+			}
+
+			$settings['postLock']['user']['syncEnabled'] = $sync_enabled;
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Add the `syncEnabled` property on the heartbeat post lock response.
+	 *
+	 * @param array{
+	 *   wp-refresh-post-lock: array{
+	 *     lock_error: array {
+	 *       syncEnabled: bool,
+	 *     },
+	 *   },
+	 * } $response Heartbeat response.
+	 * @param array{
+	 *   wp-refresh-post-lock: array{
+	 *     post_id: int,
+	 *   },
+	 * } $data     Heartbeat request data.
+	 */
+	public function enhance_heartbeat_response( array $response, array $data ): array {
+		if ( isset( $response['wp-refresh-post-lock']['lock_error'], $data['wp-refresh-post-lock']['post_id'] ) ) {
+			$post_id = intval( $data['wp-refresh-post-lock']['post_id'] );
+			$sync_enabled = false;
+
+			$lock_owner_id = wp_check_post_lock( $post_id );
+			if ( $lock_owner_id > 0 ) {
+				$lock_owner = get_user_by( 'id', $lock_owner_id );
+
+				if ( $lock_owner instanceof WP_User ) {
+					$sync_enabled = $lock_owner->has_cap( SyncPermissions::CAP_NAME, $post_id );
+				}
+			}
+
+			$response['wp-refresh-post-lock']['lock_error']['syncEnabled'] = $sync_enabled;
+		}
+
+		return $response;
+	}
+}

--- a/inc/Editor/PostLock.php
+++ b/inc/Editor/PostLock.php
@@ -32,6 +32,7 @@ final class PostLock {
 	 *    },
 	 *  },
 	 * } $settings Block editor settings.
+	 * @psalm-suppress PossiblyUnusedReturnValue
 	 */
 	public function enhance_post_lock_user( array $settings ): array {
 		global $post;
@@ -70,6 +71,7 @@ final class PostLock {
 	 *     post_id: int,
 	 *   },
 	 * } $data     Heartbeat request data.
+	 * @psalm-suppress PossiblyUnusedReturnValue
 	 */
 	public function enhance_heartbeat_response( array $response, array $data ): array {
 		if ( isset( $response['wp-refresh-post-lock']['lock_error'], $data['wp-refresh-post-lock']['post_id'] ) ) {

--- a/inc/Overrides/Overrides.php
+++ b/inc/Overrides/Overrides.php
@@ -21,9 +21,6 @@ final class Overrides {
 	 * Constructor to initialize the overrides.
 	 */
 	public function __construct() {
-		// Allow multiple users to see the edit post screen.
-		add_filter( 'show_post_locked_dialog', '__return_false' );
-
 		// Ensure that the _edit_lock meta key is never returned, effectively disabling the post lock functionality just for revisions.php.
 		add_filter( 'get_post_metadata', [ $this, 'filter_post_meta' ], 10, 3 );
 	}

--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -20,7 +20,6 @@ use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use VIPRealTimeCollaboration\Editor\CrdtPersistence;
 use VIPRealTimeCollaboration\Editor\PostLock;
 use VIPRealTimeCollaboration\Overrides\Overrides;
-use WP_User;
 
 defined( 'ABSPATH' ) || exit();
 

--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -18,7 +18,9 @@ use VIPRealTimeCollaboration\Assets\Assets;
 use VIPRealTimeCollaboration\Auth\SyncPermissions;
 use VIPRealTimeCollaboration\Compatibility\Compatibility;
 use VIPRealTimeCollaboration\Editor\CrdtPersistence;
+use VIPRealTimeCollaboration\Editor\PostLock;
 use VIPRealTimeCollaboration\Overrides\Overrides;
+use WP_User;
 
 defined( 'ABSPATH' ) || exit();
 
@@ -59,6 +61,7 @@ add_action( 'plugins_loaded', static function (): void {
 	new Compatibility();
 	new CrdtPersistence();
 	new Overrides();
+	new PostLock();
 	new RestApi();
 
 	// Fire action to indicate that the plugin has loaded.


### PR DESCRIPTION
Hide lock modal based on user access to collaborative editing feature. Companion to https://github.com/WordPress/gutenberg/pull/72644.

If we want to allow users with access to the feature to exist alongside users without access, we need a way to selectively enforce the post lock.

If both the current user and the lock owner have access to the collaborative editing feature, then we can safely ignore the post lock (but continue updating it in the background). Otherwise, defer to the current behavior of the post lock.

## Testing instructions

Use this example cap filter to test this PR by removing the `edit_with_others` cap from a user that would otherwise have it based on their role.

```php
// Filter to exclude user ID 2 from the edit_with_others capability
add_filter( 'user_has_cap', function ( array $allcaps, array $caps, array $args, WP_User $user ): array {
	// Check if we're checking for the 'edit_with_others' capability
	if ( in_array( 'edit_with_others', $caps, true ) && 2 === $user->ID ) {
		$allcaps['edit_with_others'] = false;
	}

	return $allcaps;
}, 10, 4 );
```

Then:

1. Check out this branch.
2. Check out the Gutenberg branch from [this PR](https://github.com/WordPress/gutenberg/pull/72644).
1. Open a post with user 1.
3. Open the same post with user 2.
4. Take over the post.
5. Confirm that user 1 sees a post lock dialog (after the heartbeat completes).
6. Confirm the reverse.
7. Confirm that two users with the cap intact can collaborate without a post lock dialog.