### PR TITLE
Improve awareness state management

### DIFF
--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -11,6 +11,7 @@ import * as Y from 'yjs';
  * Internal dependencies
  */
 import {
+	type UserInfo,
 	type UserState,
 	type WordPressUserInfo,
 	store as awarenessStore,
@@ -30,7 +31,6 @@ import {
 import {
 	getSelectionState,
 	SelectableBlock,
-	SelectionType,
 	updateSelectionInEntityRecord,
 } from '@/utilities/selection';
 import { getNewUserColor } from '@/utilities/user-color';
@@ -73,8 +73,8 @@ export class AwarenessManager {
 			return;
 		}
 
-		const { patchUser } = dispatch( awarenessStore );
-		void patchUser( clientId, { isConnected } );
+		const { patchUserInfo } = dispatch( awarenessStore );
+		void patchUserInfo( clientId, { isConnected } );
 	}
 
 	public static convertRelativePositionToAbsolutePosition(
@@ -94,42 +94,27 @@ export class AwarenessManager {
 	private setCurrentUserState(): void {
 		const states = this.getStates();
 		const otherUserColors = Array.from( states.values() )
-			.filter( userState => ! userState.isMe )
-			.map( userState => userState.color )
+			.filter( userState => userState.userInfo && ! userState.userInfo.isMe )
+			.map( userState => userState.userInfo.color )
 			.filter( Boolean );
 
-		const currentUserState: UserState = {
+		const userInfo: UserInfo = {
 			...this.userInfo,
 			browserType: getBrowserName(),
 			clientId: this.awareness.clientID,
 			color: getNewUserColor( otherUserColors ),
-			editorState: this.getLocalStateField( 'editorState' ) ?? {
-				selection: {
-					type: SelectionType.None,
-				},
-			},
 			isConnected: true,
 			isMe: true,
 		};
 
-		this.awareness.setLocalState( currentUserState );
+		this.setLocalStateField( 'userInfo', userInfo );
 	}
 
-	/*
+	/**
 	 * Get the states from an awareness document.
 	 */
 	private getStates(): Map< number, UserState > {
 		return this.awareness.getStates() as Map< number, UserState >;
-	}
-
-	/**
-	 * Set a local state field on an awareness document.
-	 */
-	private getLocalStateField< FieldName extends keyof UserState >(
-		field: FieldName
-	): UserState[ FieldName ] | undefined {
-		// eslint-disable-next-line security/detect-object-injection
-		return ( this.awareness.getLocalState() as UserState )?.[ field ];
 	}
 
 	/**
@@ -156,7 +141,7 @@ export class AwarenessManager {
 				return;
 			}
 
-			userState.isMe = userState.clientId === this.awareness.clientID;
+			userState.userInfo.isMe = userState.userInfo.clientId === this.awareness.clientID;
 
 			void upsertUser( clientId, userState );
 			clientIdsFromAwareness.add( clientId );
@@ -199,13 +184,13 @@ export class AwarenessManager {
 							// Ignore if we don't have a user state for the client ID
 							! userState ||
 							// Ignore if this is our own persisted event (can happen on refresh or reconnect)
-							userState.id === this.userInfo.id
+							userState.userInfo.id === this.userInfo.id
 						) {
 							break;
 						}
 
 						const status = recordMap.get( 'status' ) as string;
-						const content = getPostUpdatedNotificationContent( userState, status );
+						const content = getPostUpdatedNotificationContent( userState.userInfo, status );
 						void createNotice( 'info', content, {
 							id: `remote-user-persisted-${ remoteClientId }`,
 							isDismissible: false,
@@ -234,7 +219,7 @@ export class AwarenessManager {
 							break;
 						}
 
-						const content = getPostRestoredNotificationContent( userState );
+						const content = getPostRestoredNotificationContent( userState.userInfo );
 						void createNotice( 'info', content, {
 							id: `remote-user-restored-${ remoteClientId }`,
 							isDismissible: false,
@@ -257,6 +242,7 @@ export class AwarenessManager {
 		// in the subscription.
 		let selectionStart = getSelectionStart();
 		let selectionEnd = getSelectionEnd();
+		let localCursorTimeout: NodeJS.Timeout | null = null;
 
 		subscribe( () => {
 			const newSelectionStart = getSelectionStart();
@@ -283,7 +269,6 @@ export class AwarenessManager {
 			//   { clientId: "123...", attributeKey: "content", offset: undefined }
 			//   { clientId: "123...", attributeKey: "content", offset: 554 }
 			// Add a short debounce to avoid sending the first selection change.
-			let localCursorTimeout: NodeJS.Timeout | null = null;
 			if ( localCursorTimeout ) {
 				clearTimeout( localCursorTimeout );
 			}
@@ -298,7 +283,7 @@ export class AwarenessManager {
 		selectionStart: WPBlockSelection,
 		selectionEnd: WPBlockSelection
 	): void {
-		const { patchUser } = dispatch( awarenessStore );
+		const { updateEditorState } = dispatch( awarenessStore );
 
 		const ydocument = this.awareness.doc.getMap( 'document' );
 		const yBlocks = ydocument.get( 'blocks' ) as Y.Array< SelectableBlock >;
@@ -307,7 +292,7 @@ export class AwarenessManager {
 		};
 
 		// Update local state with the new selection state.
-		void patchUser( this.awareness.clientID, { editorState } );
+		void updateEditorState( this.awareness.clientID, editorState );
 
 		// Throttle awareness updates.
 		let awarenessCursorTimeout: NodeJS.Timeout | null = null;
@@ -330,7 +315,7 @@ export class AwarenessManager {
 
 	private subscribeToUserChanges(): void {
 		const userRemovalTimeouts = new Map< number, NodeJS.Timeout >();
-		const { patchUser, removeUser, upsertUser } = dispatch( awarenessStore );
+		const { patchUserInfo, removeUser, upsertUser } = dispatch( awarenessStore );
 
 		this.awareness.on( 'change', ( { added, removed, updated }: AwarenessStateChange ) => {
 			const updatedUserStates = this.getStates();
@@ -348,12 +333,12 @@ export class AwarenessManager {
 				}
 
 				// If this is the current user, ignore most state updates. We handle our own state locally.
-				if ( userState.clientId === this.awareness.clientID ) {
+				if ( userState.userInfo.clientId === this.awareness.clientID ) {
 					// Except reconnection updates, which we receive from awareness.
 					// This is necessary when reconnecting after a short timeout, where we
 					// receive back-to-back 'removed' and 'added' events for ourselves.
-					if ( userState.isConnected === true ) {
-						void patchUser( id, {
+					if ( userState.userInfo.isConnected === true ) {
+						void patchUserInfo( id, {
 							isConnected: true,
 						} );
 					}
@@ -361,8 +346,8 @@ export class AwarenessManager {
 					return;
 				}
 
-				userState.isConnected = true;
-				userState.isMe = false;
+				userState.userInfo.isConnected = true;
+				userState.userInfo.isMe = false;
 
 				void upsertUser( id, userState );
 			} );
@@ -374,7 +359,7 @@ export class AwarenessManager {
 					return;
 				}
 
-				void patchUser( id, {
+				void patchUserInfo( id, {
 					isConnected: false,
 				} );
 
@@ -392,7 +377,7 @@ export class AwarenessManager {
 	private validateUserState( userState: UserState | undefined ): userState is UserState {
 		// User state can be set to an empty object by the Yjs awareness protocol
 		// when the user disconnects.
-		if ( ! userState?.clientId || ! userState?.id || ! userState?.editorState ) {
+		if ( ! userState?.userInfo.clientId || ! userState?.userInfo.id ) {
 			return false;
 		}
 

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,27 +1,27 @@
-import { UserState } from '@/store/awareness-store';
+import { UserInfo } from '@/store/awareness-store';
 
 /**
  * Renders a circular avatar bubble for a user with an optional border.
  */
 export function Avatar( {
-	userState,
+	userInfo,
 	showUserColorBorder,
 }: {
-	userState: UserState;
+	userInfo: UserInfo;
 	showUserColorBorder?: boolean;
 } ) {
 	const style = {
-		border: showUserColorBorder === true ? `2px solid ${ userState.color }` : undefined,
-		opacity: userState.isConnected ? 1 : 0.5,
+		border: showUserColorBorder === true ? `2px solid ${ userInfo.color }` : undefined,
+		opacity: userInfo.isConnected ? 1 : 0.5,
 	};
 
 	return (
 		<div className="vip-real-time-collaboration-avatar">
 			<img
-				alt={ userState.name }
-				src={ userState.avatarUrl }
+				alt={ userInfo.name }
+				src={ userInfo.avatarUrl }
 				style={ style }
-				title={ userState.name }
+				title={ userInfo.name }
 			/>
 		</div>
 	);

--- a/src/components/avatars.tsx
+++ b/src/components/avatars.tsx
@@ -22,12 +22,16 @@ export function Avatars() {
 
 	const visibleUsers = activeUsers.slice( 0, 3 );
 	const remainingUsers = activeUsers.slice( 3 );
-	const remainingUsersText = remainingUsers.map( userState => userState.name ).join( ', ' );
+	const remainingUsersText = remainingUsers.map( ( { userInfo } ) => userInfo.name ).join( ', ' );
 
 	return visibleUsers.length > 1 ? (
 		<>
 			{ visibleUsers.map( userState => (
-				<Avatar key={ userState.clientId } userState={ userState } showUserColorBorder={ false } />
+				<Avatar
+					key={ userState.userInfo.clientId }
+					userInfo={ userState.userInfo }
+					showUserColorBorder={ false }
+				/>
 			) ) }
 
 			{ remainingUsers.length > 0 && (

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -141,18 +141,18 @@ export function RTCSettingsPanel() {
 
 				<Flex direction="column" className="vip-real-time-collaboration-sidebar-users" gap={ 0 }>
 					{ activeUsers.map( userState => (
-						<FlexItem key={ userState.clientId }>
+						<FlexItem key={ userState.userInfo.clientId }>
 							<Flex
 								direction="row"
 								justify="flex-start"
 								className="vip-real-time-collaboration-sidebar-user-row"
 							>
 								<Avatar
-									key={ userState.clientId }
+									key={ userState.userInfo.clientId }
 									showUserColorBorder={ true }
-									userState={ userState }
+									userInfo={ userState.userInfo }
 								/>
-								<Text>{ userState.name }</Text>
+								<Text>{ userState.userInfo.name }</Text>
 							</Flex>
 						</FlexItem>
 					) ) }

--- a/src/hooks/use-block-highlighting.ts
+++ b/src/hooks/use-block-highlighting.ts
@@ -53,14 +53,14 @@ export function useBlockHighlighting( blockEditorDocument: Document | null ) {
 			.map( userState => {
 				const isWholeBlockSelected =
 					userState.editorState?.selection?.type === SelectionType.WholeBlock;
-				const shouldDrawUser = userState.isMe ? isSelfAwarenessEnabled : true;
+				const shouldDrawUser = userState.userInfo.isMe ? isSelfAwarenessEnabled : true;
 
 				if ( isWholeBlockSelected && shouldDrawUser ) {
-					const selection = userState.editorState.selection as SelectionWholeBlock;
+					const selection = userState.editorState?.selection as SelectionWholeBlock;
 
 					return {
 						blockId: selection.blockId,
-						color: userState.color,
+						color: userState.userInfo.color,
 					};
 				}
 

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -48,11 +48,11 @@ export function useRenderCursors(
 	useEffect( () => {
 		renderCursorsRef.current = () => {
 			const userSelections = sortedUsers.map( user => ( {
-				userName: user.name,
+				userName: user.userInfo.name,
 				// Replace local user's selection with the current selection from the editor state.
-				selection: user.editorState.selection ?? { type: SelectionType.None },
-				color: user.color,
-				isMe: user.isMe,
+				selection: user.editorState?.selection ?? { type: SelectionType.None },
+				color: user.userInfo.color,
+				isMe: user.userInfo.isMe,
 			} ) );
 
 			drawUserSelections( overlayRef.current, blockEditorDocument, userSelections, drawType );

--- a/src/hooks/use-sorted-awareness-users.tsx
+++ b/src/hooks/use-sorted-awareness-users.tsx
@@ -17,10 +17,10 @@ export function useSortedAwarenessUsers(): UserState[] {
 
 	return useMemo( () => {
 		return Array.from( activeUsers.values() ).sort( ( user1: UserState, user2: UserState ) => {
-			if ( user1.isMe && ! user2.isMe ) {
+			if ( user1.userInfo.isMe && ! user2.userInfo.isMe ) {
 				return -1;
 			}
-			if ( ! user1.isMe && user2.isMe ) {
+			if ( ! user1.userInfo.isMe && user2.userInfo.isMe ) {
 				return 1;
 			}
 			return 0;

--- a/src/store/awareness-store.ts
+++ b/src/store/awareness-store.ts
@@ -2,17 +2,21 @@ import { User } from '@wordpress/core-data';
 import { register, createReduxStore, StoreDescriptor } from '@wordpress/data';
 
 import { type SelectionState } from '@/utilities/selection';
-import { areUserStatesEqual } from '@/utilities/user';
+import { areEditorStatesEqual, areUserInfosEqual, areUserStatesEqual } from '@/utilities/user';
 
 const STORE_NAME = 'vip-real-time-collaboration/awareness';
 
 export type WordPressUserInfo = Pick< User, 'id' | 'name' > & { avatarUrl?: string };
 
-export interface UserState extends WordPressUserInfo {
-	browserType: string;
+export interface UserState {
+	editorState?: EditorState;
+	userInfo: UserInfo;
+}
+
+export interface UserInfo extends WordPressUserInfo {
 	clientId: number;
+	browserType: string;
 	color: string;
-	editorState: EditorState;
 	isConnected: boolean;
 	isMe: boolean;
 }
@@ -25,9 +29,9 @@ export interface AwarenessStore {
 	userMap: Map< number, UserState >;
 }
 
-interface PatchUserAction {
-	type: 'PATCH_USER';
-	payload: { clientId: number; userState: Partial< UserState > };
+interface PatchUserInfoAction {
+	type: 'PATCH_USER_INFO';
+	payload: { clientId: number; userInfo: Partial< UserInfo > };
 }
 
 interface RemoveUserAction {
@@ -35,9 +39,9 @@ interface RemoveUserAction {
 	payload: { clientId: number };
 }
 
-interface SetCurrentUserSelectionAction {
-	type: 'SET_CURRENT_USER_SELECTION';
-	payload: { selection: SelectionState };
+interface UpdateEditorStateAction {
+	type: 'UPDATE_EDITOR_STATE';
+	payload: { clientId: number; editorState: EditorState };
 }
 
 interface UpsertUserAction {
@@ -46,9 +50,9 @@ interface UpsertUserAction {
 }
 
 type AwarenessAction =
-	| PatchUserAction
+	| PatchUserInfoAction
 	| RemoveUserAction
-	| SetCurrentUserSelectionAction
+	| UpdateEditorStateAction
 	| UpsertUserAction;
 
 const DEFAULT_STATE: AwarenessStore = {
@@ -56,15 +60,20 @@ const DEFAULT_STATE: AwarenessStore = {
 };
 
 const actions = {
-	patchUser: ( clientId: number, userState: Partial< UserState > ): AwarenessAction => ( {
-		type: 'PATCH_USER',
-		payload: { clientId, userState },
+	patchUserInfo: ( clientId: number, userInfo: Partial< UserInfo > ): AwarenessAction => ( {
+		type: 'PATCH_USER_INFO',
+		payload: { clientId, userInfo },
 	} ),
 
 	// Call when a user leaves the editor (after a delay)
 	removeUser: ( clientId: number ): AwarenessAction => ( {
 		type: 'REMOVE_USER',
 		payload: { clientId },
+	} ),
+
+	updateEditorState: ( clientId: number, editorState: EditorState ): AwarenessAction => ( {
+		type: 'UPDATE_EDITOR_STATE',
+		payload: { clientId, editorState },
 	} ),
 
 	upsertUser: ( clientId: number, userState: UserState ): AwarenessAction => ( {
@@ -75,31 +84,61 @@ const actions = {
 
 const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessStore => {
 	switch ( action.type ) {
-		case 'PATCH_USER': {
-			if ( state.userMap.has( action.payload.clientId ) ) {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const existingState = state.userMap.get( action.payload.clientId )!;
-				const updatedState = {
-					...existingState,
-					...action.payload.userState,
-				};
-
-				if ( ! areUserStatesEqual( existingState, updatedState ) ) {
-					state.userMap.set( action.payload.clientId, updatedState );
-
-					return {
-						...state,
-						userMap: new Map( state.userMap ),
-					};
-				}
+		case 'PATCH_USER_INFO': {
+			if ( ! state.userMap.has( action.payload.clientId ) ) {
+				return state;
 			}
 
-			// No changes, don't update the state.
-			return state;
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const existingState = state.userMap.get( action.payload.clientId )!;
+			const updatedState = {
+				...existingState,
+				userInfo: {
+					...existingState.userInfo,
+					...action.payload.userInfo,
+				},
+			};
+
+			if ( areUserInfosEqual( existingState.userInfo, updatedState.userInfo ) ) {
+				// No changes, don't update the state.
+				return state;
+			}
+
+			state.userMap.set( action.payload.clientId, updatedState );
+
+			return {
+				...state,
+				userMap: new Map( state.userMap ),
+			};
 		}
 
 		case 'REMOVE_USER': {
 			state.userMap.delete( action.payload.clientId );
+
+			return {
+				...state,
+				userMap: new Map( state.userMap ),
+			};
+		}
+
+		case 'UPDATE_EDITOR_STATE': {
+			if ( ! state.userMap.has( action.payload.clientId ) ) {
+				return state;
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const existingState = state.userMap.get( action.payload.clientId )!;
+			const updatedState = {
+				...existingState,
+				editorState: action.payload.editorState,
+			};
+
+			if ( areEditorStatesEqual( existingState.editorState, updatedState.editorState ) ) {
+				// No changes, don't update the state.
+				return state;
+			}
+
+			state.userMap.set( action.payload.clientId, updatedState );
 
 			return {
 				...state,
@@ -141,7 +180,7 @@ const selectors = {
 	isDisconnected( state: AwarenessStore ): boolean {
 		return (
 			Array.from( selectors.getActiveUsers( state ).values() ).findIndex(
-				user => user.isMe && false === user.isConnected
+				user => user.userInfo.isMe && false === user.userInfo.isConnected
 			) !== -1
 		);
 	},

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -7,7 +7,7 @@ import type { WordPressUserInfo } from '@/store/awareness-store';
 import type { ObjectData, SyncConfig } from '@wordpress/sync';
 
 export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
-	const { avatar_urls: avatarUrls, id, name } = select( coreStore ).getCurrentUser() ?? {};
+	const { avatar_urls: avatarUrls, id, name, slug } = select( coreStore ).getCurrentUser() ?? {};
 
 	if ( ! id ) {
 		// getCurrentUser() returns an empty user object for a short time after load.
@@ -17,7 +17,7 @@ export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 	}
 	const avatarUrl = avatarUrls?.[ 24 ] || avatarUrls?.[ 48 ] || avatarUrls?.[ 96 ];
 
-	return { avatarUrl, id, name };
+	return { avatarUrl, id, name: name ?? slug };
 }
 
 export async function getHashForEntityRecord(

--- a/src/utilities/notifications.test.ts
+++ b/src/utilities/notifications.test.ts
@@ -6,34 +6,32 @@ import {
 	getPostUpdatedNotificationContent,
 } from './notifications';
 
-import type { UserState } from '@/store/awareness-store';
-import type { SelectionState } from '@/utilities/selection';
+import type { UserInfo } from '@/store/awareness-store';
 
-const baseUserState: UserState = {
+const baseUserInfo: UserInfo = {
 	id: 1,
 	name: 'Alice',
+	clientId: 123,
 	color: '#000000',
 	browserType: 'chrome',
-	clientId: 1,
-	editorState: { selection: {} as SelectionState },
 	isConnected: true,
 	isMe: false,
 };
 
 describe( 'getPostRestoredNotificationContent', () => {
 	it( 'should return formatted message with user name', () => {
-		const result = getPostRestoredNotificationContent( baseUserState );
+		const result = getPostRestoredNotificationContent( baseUserInfo );
 
 		assert.strictEqual( result, 'Alice restored newer content from the server.' );
 	} );
 
 	it( 'should omit the name if the user is me', () => {
-		const userState: UserState = {
-			...baseUserState,
+		const userInfo: UserInfo = {
+			...baseUserInfo,
 			isMe: true,
 		};
 
-		const result = getPostRestoredNotificationContent( userState );
+		const result = getPostRestoredNotificationContent( userInfo );
 
 		assert.strictEqual( result, 'Restored newer content from the server.' );
 	} );
@@ -41,37 +39,37 @@ describe( 'getPostRestoredNotificationContent', () => {
 
 describe( 'getPostUpdatedNotificationContent', () => {
 	it( 'should return "Draft" for draft status', () => {
-		const result = getPostUpdatedNotificationContent( baseUserState, 'draft' );
+		const result = getPostUpdatedNotificationContent( baseUserInfo, 'draft' );
 
 		assert.strictEqual( result, 'Draft saved by Alice.' );
 	} );
 
 	it( 'should return "Draft" for auto-draft status', () => {
-		const result = getPostUpdatedNotificationContent( baseUserState, 'auto-draft' );
+		const result = getPostUpdatedNotificationContent( baseUserInfo, 'auto-draft' );
 
 		assert.strictEqual( result, 'Draft saved by Alice.' );
 	} );
 
 	it( 'should return "Post" for publish status', () => {
-		const result = getPostUpdatedNotificationContent( baseUserState, 'publish' );
+		const result = getPostUpdatedNotificationContent( baseUserInfo, 'publish' );
 
 		assert.strictEqual( result, 'Post updated by Alice.' );
 	} );
 
 	it( 'should return "Post" for private status', () => {
-		const result = getPostUpdatedNotificationContent( baseUserState, 'private' );
+		const result = getPostUpdatedNotificationContent( baseUserInfo, 'private' );
 
 		assert.strictEqual( result, 'Post updated by Alice.' );
 	} );
 
 	it( 'should return "Post" for future status', () => {
-		const result = getPostUpdatedNotificationContent( baseUserState, 'future' );
+		const result = getPostUpdatedNotificationContent( baseUserInfo, 'future' );
 
 		assert.strictEqual( result, 'Post updated by Alice.' );
 	} );
 
 	it( 'should return "Draft" for unknown status', () => {
-		const result = getPostUpdatedNotificationContent( baseUserState, 'unknown-status' );
+		const result = getPostUpdatedNotificationContent( baseUserInfo, 'unknown-status' );
 
 		assert.strictEqual( result, 'Draft saved by Alice.' );
 	} );

--- a/src/utilities/notifications.ts
+++ b/src/utilities/notifications.ts
@@ -1,15 +1,15 @@
-import type { UserState } from '@/store/awareness-store';
+import type { UserInfo } from '@/store/awareness-store';
 
-export function getPostRestoredNotificationContent( userState: UserState ): string {
-	let predicate = `${ userState.name } restored`;
-	if ( userState.isMe ) {
+export function getPostRestoredNotificationContent( userInfo: UserInfo ): string {
+	let predicate = `${ userInfo.name } restored`;
+	if ( userInfo.isMe ) {
 		predicate = 'Restored';
 	}
 
 	return `${ predicate } newer content from the server.`;
 }
 
-export function getPostUpdatedNotificationContent( userState: UserState, status: string ): string {
+export function getPostUpdatedNotificationContent( userInfo: UserInfo, status: string ): string {
 	let noun = 'Draft';
 	let verb = 'saved';
 
@@ -18,5 +18,5 @@ export function getPostUpdatedNotificationContent( userState: UserState, status:
 		verb = 'updated';
 	}
 
-	return `${ noun } ${ verb } by ${ userState.name }.`;
+	return `${ noun } ${ verb } by ${ userInfo.name }.`;
 }

--- a/src/utilities/user.ts
+++ b/src/utilities/user.ts
@@ -1,23 +1,25 @@
-import { areSelectionsEqual } from './selection';
-import { EditorState, type UserState } from '@/store/awareness-store';
+import { areSelectionsEqual } from '@/utilities/selection';
+
+import type { EditorState, UserInfo, UserState } from '@/store/awareness-store';
 
 export function areUserStatesEqual( userState1: UserState, userState2: UserState ): boolean {
-	if ( Object.keys( userState1 ).length !== Object.keys( userState2 ).length ) {
+	return (
+		areUserInfosEqual( userState1.userInfo, userState2.userInfo ) &&
+		areEditorStatesEqual( userState1.editorState, userState2.editorState )
+	);
+}
+
+export function areUserInfosEqual( userInfo1: UserInfo, userInfo2: UserInfo ): boolean {
+	if ( Object.keys( userInfo1 ).length !== Object.keys( userInfo2 ).length ) {
 		return false;
 	}
 
-	return Object.entries( userState1 ).every( ( [ key, value ] ) => {
-		// Update this switch with any non-primitive fields added to UserState.
-		switch ( key ) {
-			case 'editorState':
-				return areEditorStatesEqual( userState1.editorState, userState2.editorState );
-
-			default:
-				return value === userState2[ key as keyof UserState ];
-		}
+	return Object.entries( userInfo1 ).every( ( [ key, value ] ) => {
+		// Update this function with any non-primitive fields added to UserInfo.
+		return value === userInfo2[ key as keyof UserInfo ];
 	} );
 }
 
-function areEditorStatesEqual( state1?: EditorState, state2?: EditorState ): boolean {
+export function areEditorStatesEqual( state1?: EditorState, state2?: EditorState ): boolean {
 	return Boolean( state1 && state2 && areSelectionsEqual( state1.selection, state2.selection ) );
 }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -234,7 +234,9 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 			return {
 				destroy: () => provider.destroy(),
 			};
-		} catch {}
+		} catch ( err ) {
+			logger.critical( 'Failed to create WebSocket connection', { error: err } );
+		}
 
 		return defaultResult;
 	};


### PR DESCRIPTION
Initially, this was an attempt to fix a report of excessive awareness state updates reported during a demo. Users observed the entire state object being transmitted periodically over the socket connection.

My theory was that mixing the selection state in with user info resulting in the entire state object being transmitted unnecessarily. However, upon looking at the Yjs Awareness code, it's clear that this is done intentionally as a kind of heartbeat implementation:

https://github.com/yjs/y-protocols/blob/2d8cd5c06b3925fbf9b5215dc341f8096a0a8d5c/awareness.js

It's my opinion that we shouldn't spend much time trying to optimize this right now. The awareness state is already fairly minimal and is unlikely to be a performance drag. 

However, separating the selection into its own top-level state field is a code improvement. I also fixed two bugs:

1. The debounce timeout in `subscribeToSelectionChanges` was not in the outer scope and was always set to `null`. This is fixed and the debouncing now works as intended.
2. Fallback to `user.slug` when `user.name` is undefined. This prevents toasts like "undefined did X."

