### PR TITLE
Enable eslint and fix linting issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,7 @@ build
 node_modules
 vendor
 *.php
-websocket-server
 yjs-inspector
 tests/e2e
 examples/
+websocket-server

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,4 @@ vendor
 *.php
 yjs-inspector
 tests/e2e
-examples/
 websocket-server

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,4 @@ vendor
 *.php
 yjs-inspector
 tests/e2e
-websocket-server/dist
-websocket-server/node_modules
+websocket-server

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,7 @@ build
 node_modules
 vendor
 *.php
-websocket-server/node_modules
-websocket-server/dist
+websocket-server
+yjs-inspector
+tests/e2e
+examples/

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,5 @@ vendor
 *.php
 yjs-inspector
 tests/e2e
-websocket-server
+websocket-server/dist
+websocket-server/node_modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,5 @@ vendor
 *.php
 yjs-inspector
 tests/e2e
-websocket-server
+websocket-server/node_modules
+websocket-server/dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '*.test.ts' ], // Node.js unit tests
+			files: [ '*.test.ts' ], // Node.js unit tests and e2e tests
 			rules: {
 				'@typescript-eslint/no-explicit-any': 'off',
 				'@typescript-eslint/no-floating-promises': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '*.test.ts' ], // Node.js unit tests and e2e tests
+			files: [ '*.test.ts' ], // Node.js unit tests
 			rules: {
 				'@typescript-eslint/no-explicit-any': 'off',
 				'@typescript-eslint/no-floating-promises': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,15 +30,5 @@ module.exports = {
 				'no-unused-vars': 'off', // Allow unused vars in example code
 			},
 		},
-		{
-			files: [ 'websocket-server/**/*.ts' ], // Websocket server has its own tsconfig
-			parserOptions: {
-				project: './websocket-server/tsconfig.json',
-				tsconfigRootDir: __dirname,
-			},
-			rules: {
-				'@typescript-eslint/no-misused-promises': 'off', // ignore the misused promises rule in websocket server code
-			},
-		},
 	],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,5 +30,15 @@ module.exports = {
 				'no-unused-vars': 'off', // Allow unused vars in example code
 			},
 		},
+		{
+			files: [ 'websocket-server/**/*.ts' ], // Websocket server has its own tsconfig
+			parserOptions: {
+				project: './websocket-server/tsconfig.json',
+				tsconfigRootDir: __dirname,
+			},
+			rules: {
+				'@typescript-eslint/no-misused-promises': 'off', // ignore the misused promises rule in websocket server code
+			},
+		},
 	],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,5 +30,14 @@ module.exports = {
 				'no-unused-vars': 'off', // Allow unused vars in example code
 			},
 		},
+		{
+			files: [ 'websocket-server/**/*.ts' ], // Websocket server has its own tsconfig
+			parserOptions: {
+				project: './websocket-server/tsconfig.json',
+			},
+			rules: {
+				'@typescript-eslint/no-misused-promises': 'off', // ignore the misused promises rule in websocket server code
+			},
+		},
 	],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,8 @@ module.exports = {
 		{
 			files: [ 'websocket-server/**/*.ts' ], // Websocket server has its own tsconfig
 			parserOptions: {
-				project: './websocket-server/tsconfig.json',
+				project: true,
+				tsconfigRootDir: __dirname,
 			},
 			rules: {
 				'@typescript-eslint/no-misused-promises': 'off', // ignore the misused promises rule in websocket server code

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,20 @@ module.exports = {
 				'@typescript-eslint/no-unsafe-assignment': 'off',
 			},
 		},
+		{
+			files: [ 'examples/**/*.js' ], // Examples use JSX in .js files
+			parserOptions: {
+				requireConfigFile: false,
+				babelOptions: {
+					presets: [ '@babel/preset-react' ],
+				},
+				ecmaFeatures: {
+					jsx: true,
+				},
+			},
+			rules: {
+				'no-unused-vars': 'off', // Allow unused vars in example code
+			},
+		},
 	],
 };

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,9 @@ jobs:
           node-version-file: .nvmrc
           ignore-scripts: true
 
+      - name: Install websocket-server dependencies
+        run: npm install --ignore-scripts --prefix websocket-server
+
       - name: Check formatting
         run: npm run format:check
 

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+	'*.css': [ 'npm run lint:css' ],
+	'*.{js,jsx,ts,tsx}': [ () => 'npm run check-types', 'npm run lint' ],
+	'*.php': [ 'npm run lint:php' ],
+	'*.{js,json,jsx,md,ts,tsx,yml,yaml}': [ 'npm run format:check' ],
+};

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	'*.css': [ 'npm run lint:css' ],
-	'*.{js,jsx,ts,tsx}': [ () => 'npm run check-types', 'npm run lint' ],
+	'*.{js,jsx,ts,tsx}': [ () => 'npm run lint' ],
 	'*.php': [ 'npm run lint:php' ],
 	'*.{js,json,jsx,md,ts,tsx,yml,yaml}': [ 'npm run format:check' ],
 };

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,0 @@
-{
-  "*.css": [ "npm run lint:css" ],
-  "*.{js,jsx,ts,tsx}": [ "npm run lint" ],
-  "*.php": [ "npm run lint:php" ],
-  "*.{js,json,jsx,md,ts,tsx,yml,yaml}": [ "npm run format:check" ]
-}

--- a/examples/local-updates-block/package.json
+++ b/examples/local-updates-block/package.json
@@ -21,6 +21,7 @@
 		"@wordpress/block-editor": "15.3.0",
 		"@wordpress/blocks": "15.3.0",
 		"@wordpress/components": "30.3.0",
+		"@wordpress/element": "^6.26.0",
 		"@wordpress/i18n": "6.3.0"
 	}
 }

--- a/examples/local-updates-block/src/wikipedia-edits/edit.js
+++ b/examples/local-updates-block/src/wikipedia-edits/edit.js
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * A block that displays recent Wikipedia edits. It allows the user to refresh

--- a/examples/post-meta-block/src/subtitle/edit.js
+++ b/examples/post-meta-block/src/subtitle/edit.js
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 import { TextControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * A "post meta block" that allows the user to provide a subtitle for the post.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev:yjs-inspector": "cd yjs-inspector && npm run dev",
     "format": "npm run cmd:format -- --write",
     "format:check": "npm run cmd:format -- --check",
-    "lint": "npm run format:check && npm run lint:js && npm run lint:css && npm run lint:php",
+    "lint": "npm run format:check && npm run lint:js && npm run lint:css && npm run lint:php && npm run check-types",
     "lint:css": "echo 'No CSS files have been committed yet.' # wp-scripts lint-style",
     "lint:css:fix": "wp-scripts lint-style --fix",
     "lint:js": "npm run cmd:lint:js",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:css": "echo 'No CSS files have been committed yet.' # wp-scripts lint-style",
     "lint:css:fix": "wp-scripts lint-style --fix",
     "lint:js": "npm run cmd:lint:js",
-    "lint:js:fix": "npm run cmd:lint:js . -- --fix",
+    "lint:js:fix": "npm run cmd:lint:js -- --fix",
     "lint:php": "npm run lint:phpcs && npm run lint:psalm",
     "lint:phpcs": "vendor/bin/phpcs --cache",
     "lint:phpcs:fix": "vendor/bin/phpcbf",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "check-types": "tsc --noEmit",
     "cmd:build": "WP_DEVTOOL=source-map wp-scripts build --experimental-modules",
     "cmd:format": "prettier '**/*.(js|json|jsx|md|ts|tsx|yml|yaml)'",
-    "cmd:lint:js": "eslint --ext 'js,jsx,ts,tsx' --quiet",
+    "cmd:lint:js": "eslint --ext 'js,jsx,ts,tsx' --quiet .",
     "dev": "./bin/start",
     "dev:destroy": "./bin/stop destroy",
     "dev:stop": "./bin/stop",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "GPL-2.0-or-later",
   "scripts": {
     "build": "npm run cmd:build",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --skipLibCheck --allowJS --noEmit",
     "cmd:build": "WP_DEVTOOL=source-map wp-scripts build --experimental-modules",
     "cmd:format": "prettier '**/*.(js|json|jsx|md|ts|tsx|yml|yaml)'",
     "cmd:lint:js": "eslint --ext 'js,jsx,ts,tsx' --quiet .",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "GPL-2.0-or-later",
   "scripts": {
     "build": "npm run cmd:build",
-    "check-types": "tsc --skipLibCheck --allowJS --noEmit",
+    "check-types": "tsc --noEmit",
     "cmd:build": "WP_DEVTOOL=source-map wp-scripts build --experimental-modules",
     "cmd:format": "prettier '**/*.(js|json|jsx|md|ts|tsx|yml|yaml)'",
     "cmd:lint:js": "eslint --ext 'js,jsx,ts,tsx' --quiet .",
@@ -31,7 +31,7 @@
     "dev:yjs-inspector": "cd yjs-inspector && npm run dev",
     "format": "npm run cmd:format -- --write",
     "format:check": "npm run cmd:format -- --check",
-    "lint": "npm run format:check && npm run lint:js && npm run lint:css && npm run lint:php && npm run check-types",
+    "lint": "npm run format:check && npm run lint:js && npm run lint:css && npm run lint:php",
     "lint:css": "echo 'No CSS files have been committed yet.' # wp-scripts lint-style",
     "lint:css:fix": "wp-scripts lint-style --fix",
     "lint:js": "npm run cmd:lint:js",

--- a/src/components/read-only-code-editor.tsx
+++ b/src/components/read-only-code-editor.tsx
@@ -14,10 +14,9 @@ export function ReadOnlyCodeEditor() {
 	// Get the current editor mode (visual or text).
 	// Visual mode is the default block editor mode.
 	// Text mode is the code editor mode.
-	const editorMode = useSelect< EditPostStoreSelectors, 'visual' | 'text' | undefined >( select => {
-		const { getEditorMode } = select( editPostStore );
-		return getEditorMode();
-	} );
+	const editorMode = useSelect< EditPostStoreSelectors, 'visual' | 'text' | undefined >( select =>
+		select( editPostStore ).getEditorMode()
+	);
 
 	// When in text mode, set the code editor (textarea) to read-only.
 	useEffect( () => {

--- a/src/hooks/use-copy-post-content-to-clipboard.ts
+++ b/src/hooks/use-copy-post-content-to-clipboard.ts
@@ -3,10 +3,9 @@ import { useSelect } from '@wordpress/data';
 import { type EditorStoreSelectors, store as editorStore } from '@wordpress/editor';
 
 export function useCopyPostContentToClipboard( onSuccess: () => void = () => {} ) {
-	const postContent = useSelect< EditorStoreSelectors, string | null >( select => {
-		const { getEditedPostContent } = select( editorStore );
-		return getEditedPostContent();
-	} );
+	const postContent = useSelect< EditorStoreSelectors, string | null >( select =>
+		select( editorStore ).getEditedPostContent()
+	);
 
 	return useCopyToClipboard( postContent ?? '', onSuccess );
 }

--- a/src/hooks/use-current-entity.ts
+++ b/src/hooks/use-current-entity.ts
@@ -13,11 +13,9 @@ export function useCurrentEntity(): CurrentEntity | null {
 		EditorStoreSelectors,
 		{ postId: number | null; postType: string | null }
 	>( select => {
-		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
-
 		return {
-			postId: getCurrentPostId(),
-			postType: getCurrentPostType(),
+			postId: select( editorStore ).getCurrentPostId(),
+			postType: select( editorStore ).getCurrentPostType(),
 		};
 	} );
 

--- a/types/wordpress__edit-post/index.d.ts
+++ b/types/wordpress__edit-post/index.d.ts
@@ -1,7 +1,7 @@
 declare module '@wordpress/edit-post' {
 	import type { StoreDescriptor } from '@wordpress/data';
 
-	export const store: StoreDescriptor< any >;
+	export const store: StoreDescriptor;
 
 	export interface EditPostStoreSelectors {
 		getEditorMode(): 'visual' | 'text' | undefined;

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -1,4 +1,5 @@
 import '@wordpress/editor';
+import type { PrivateApis } from '@wordpress/private-apis';
 
 declare module '@wordpress/editor' {
 	interface EditorStoreSelectors {
@@ -7,5 +8,9 @@ declare module '@wordpress/editor' {
 		getEditedPostContent(): string | null;
 	}
 
-	const EditorPresence: React.FC< React.PropsWithChildren >;
+	export interface EditorPrivateApis {
+		EditorPresence: React.FC< React.PropsWithChildren >;
+	}
+
+	export const privateApis: PrivateApis< EditorPrivateApis >;
 }

--- a/types/wordpress__private-apis/index.d.ts
+++ b/types/wordpress__private-apis/index.d.ts
@@ -1,0 +1,12 @@
+declare module '@wordpress/private-apis' {
+	export interface PrivateApis< T > {
+		__unstablePrivateApis: T;
+	}
+
+	export function __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		message: string,
+		moduleName: string
+	): {
+		unlock< T >( this: void, privateApis: PrivateApis< T > ): T;
+	};
+}

--- a/websocket-server/index.ts
+++ b/websocket-server/index.ts
@@ -2,6 +2,7 @@ import { setPersistence, setupWSConnection } from '@y/websocket-server/utils';
 import http from 'http';
 import jwt from 'jsonwebtoken';
 import { WebSocketServer } from 'ws';
+
 import {
 	recordMessage,
 	recordAuthFailure,
@@ -169,7 +170,7 @@ function isRequestAuthenticated( request: http.IncomingMessage ): AuthResult {
  * Server Configuration
  * ------------------------------------------------------------
  */
-const server = http.createServer( async ( request, response ) => {
+const server = http.createServer( ( request, response ) => {
 	const pathname = getRequestPathname( request );
 
 	if ( [ '/cache-healthcheck', '/health', '/ready' ].includes( pathname ) ) {

--- a/websocket-server/metrics.ts
+++ b/websocket-server/metrics.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import { register, Counter, Gauge, Histogram } from 'prom-client';
+
 import type { RawData, WebSocketServer } from 'ws';
 
 /**


### PR DESCRIPTION
### Description

As noted internally, eslint wasn't running correctly as the path wasn't provided. Providing a path also means the actual eslint problems will start to come up so those have to be fixed.

Everything's been fixed, and the only folders that have been ignored are:

- yjs-inspector: This is the inspector code that we don't own
- tests/e2e: All of these e2e tests are currently disabled as they are flaky. There's no point trying to fix them if in trying to fix it, half the code is changed. I've punted it to when the tests are actually fixed.