### PR TITLE
Improve lint relaxation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,10 +9,7 @@ module.exports = {
 		{
 			files: [ '*.test.ts' ], // Node.js unit tests
 			rules: {
-				'@typescript-eslint/no-explicit-any': 'off',
 				'@typescript-eslint/no-floating-promises': 'off',
-				'@typescript-eslint/no-unsafe-argument': 'off',
-				'@typescript-eslint/no-unsafe-assignment': 'off',
 			},
 		},
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,9 +36,6 @@ module.exports = {
 				project: true,
 				tsconfigRootDir: __dirname,
 			},
-			rules: {
-				'@typescript-eslint/no-misused-promises': 'off', // ignore the misused promises rule in websocket server code
-			},
 		},
 	],
 };

--- a/websocket-server/metrics.ts
+++ b/websocket-server/metrics.ts
@@ -194,6 +194,12 @@ function checkReconnection( connectionId: string | null ): void {
  * ------------------------------------------------------------
  */
 export function createMetricsServer(): http.Server {
+	// This is technically a type mismatch, but the function is async for syntactic
+	// benefits. Node.js ignores the return value of the function and manages the
+	// lifecycle of the request via `res` -- e.g., when `res.end()` is called, not
+	// when the promise resolves.
+	//
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	return http.createServer( async ( request, response ) => {
 		const pathname = getRequestPathname( request );
 


### PR DESCRIPTION
Improve lint relaxation by explaining the issue and restricting the override to a single instance (always better than a blanket disablement IMO).

Additionally, remove unneeded relaxations in test files.