### PR TITLE
fix cursor not drawn for current user even when configured

### DIFF
--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -97,10 +97,9 @@ const drawUserSelections = (
 		return;
 	}
 
-	// Draw cursors
 	userSelections.forEach( ( { userName, clientId, selection, color, isMe } ) => {
-		if ( isMe ) {
-			// Skip current user's cursor - they're never shown in the UI
+		if ( isMe && drawType === DrawType.OtherUsers ) {
+			// Skip drawing the local user's cursor.
 			return;
 		}
 


### PR DESCRIPTION
A commit in PR #86 introduced bug where the cursor was not drawn for current user even when configured. This reverts that change to fix it.