### PR TITLE
Pass cursor registry as shared prop

### DIFF
--- a/src/components/avatars.tsx
+++ b/src/components/avatars.tsx
@@ -4,14 +4,19 @@ import { useState } from '@wordpress/element';
 import { Avatar } from '@/components/avatar';
 import { CollaboratorsList } from '@/components/collaborators-list';
 import { useSortedAwarenessUsers } from '@/hooks/use-sorted-awareness-users';
+import { type CursorRegistry } from '@/utilities/cursor-registry';
 
 import '@/components/avatars.scss';
+
+interface AvatarsProps {
+	cursorRegistry: CursorRegistry;
+}
 
 /**
  * Renders a list of avatars for the active users, with a maximum of 3 visible avatars.
  * Shows a popover with all users on hover.
  */
-export function Avatars() {
+export function Avatars( { cursorRegistry }: AvatarsProps ) {
 	const activeUsers = useSortedAwarenessUsers();
 
 	// Filter out current user - we never show ourselves in the list
@@ -59,6 +64,7 @@ export function Avatars() {
 			{ isPopoverVisible && (
 				<CollaboratorsList
 					activeUsers={ otherActiveUsers }
+					cursorRegistry={ cursorRegistry }
 					popoverAnchor={ popoverAnchor }
 					setIsPopoverVisible={ setIsPopoverVisible }
 				/>

--- a/src/components/collaborators-list.tsx
+++ b/src/components/collaborators-list.tsx
@@ -3,13 +3,14 @@ import { Popover, Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 
 import { Avatar } from '@/components/avatar';
-import { cursorRegistry } from '@/contexts/cursor-registry-context';
 import { type UserState } from '@/store/awareness-store';
+import { type CursorRegistry } from '@/utilities/cursor-registry';
 
 import '@/components/collaborators-list.scss';
 
 interface CollaboratorsListProps {
 	activeUsers: UserState[];
+	cursorRegistry: CursorRegistry;
 	popoverAnchor?: HTMLElement | null;
 	setIsPopoverVisible: ( isVisible: boolean ) => void;
 }
@@ -20,6 +21,7 @@ interface CollaboratorsListProps {
  */
 export function CollaboratorsList( {
 	activeUsers,
+	cursorRegistry,
 	popoverAnchor,
 	setIsPopoverVisible,
 }: CollaboratorsListProps ) {

--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -3,17 +3,19 @@ import { useRef, useState, useEffect } from '@wordpress/element';
 
 import { useBlockHighlighting } from '@/hooks/use-block-highlighting';
 import { useRenderCursors } from '@/hooks/use-render-cursors';
+import { type CursorRegistry } from '@/utilities/cursor-registry';
 
 import '@/components/rtc-overlay.scss';
 
 interface RTCOverlayProps {
 	containerRef: React.MutableRefObject< HTMLElement | null >;
+	cursorRegistry: CursorRegistry;
 }
 
 /**
  * This component is responsible for rendering awareness components within the editor iframe.
  */
-export function RTCOverlay( { containerRef }: RTCOverlayProps ) {
+export function RTCOverlay( { containerRef, cursorRegistry }: RTCOverlayProps ) {
 	const overlayRef = useRef< HTMLDivElement >( null );
 	const [ document, setDocument ] = useState< Document | null >( null );
 
@@ -32,7 +34,7 @@ export function RTCOverlay( { containerRef }: RTCOverlayProps ) {
 		}
 	}, [] );
 
-	const renderCursorsRef = useRenderCursors( overlayRef, document );
+	const renderCursorsRef = useRenderCursors( overlayRef, document, cursorRegistry );
 
 	// Detect layout changes on overlay (e.g. turning on "Show Template") and window
 	// resizes, and re-render the cursors.

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -2,6 +2,7 @@ import { BlockCanvasCover } from '@wordpress/block-editor';
 import { ToggleControl, __experimentalHeading as Heading } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel, privateApis as editorPrivateApis } from '@wordpress/editor';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
@@ -16,6 +17,7 @@ import {
 	type SettingsStoreSelectors,
 } from '../store/settings-store';
 import { isDevelopment } from '@/utilities/config';
+import { CursorRegistry } from '@/utilities/cursor-registry';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
@@ -58,18 +60,19 @@ export function RTCSettingsPanel() {
 	}, [] );
 
 	const { setSetting } = useDispatch< SettingsStoreActions >( rtcSettingsStore );
+	const cursorRegistry = useRef< CursorRegistry >( new CursorRegistry() );
 
 	return (
 		<>
 			{ isAvatarsEnabled && (
 				<EditorPresence>
-					<Avatars />
+					<Avatars cursorRegistry={ cursorRegistry.current } />
 				</EditorPresence>
 			) }
 			<BlockCanvasCover.Fill>
 				{ ( { containerRef }: { containerRef: React.MutableRefObject< HTMLElement | null > } ) => (
 					<>
-						<RTCOverlay containerRef={ containerRef } />
+						<RTCOverlay containerRef={ containerRef } cursorRegistry={ cursorRegistry.current } />
 						{ isDebugToolsEnabled && containerRef.current?.ownerDocument && (
 							<DebugTools iframeDocument={ containerRef.current?.ownerDocument } />
 						) }

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -60,6 +60,9 @@ export function RTCSettingsPanel() {
 	}, [] );
 
 	const { setSetting } = useDispatch< SettingsStoreActions >( rtcSettingsStore );
+
+	// A single instance of the cursor registry is shared between Avatars and
+	// RTCOverlay. A ref is used to persist the instance across re-renders.
 	const cursorRegistry = useRef< CursorRegistry >( new CursorRegistry() );
 
 	return (

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -2,9 +2,9 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
 import { AwarenessManager } from '@/awareness-manager';
-import { cursorRegistry } from '@/contexts/cursor-registry-context';
 import { useSortedAwarenessUsers } from '@/hooks/use-sorted-awareness-users';
 import { store as rtcSettingsStore, Setting, SettingsStoreSelectors } from '@/store/settings-store';
+import { type CursorRegistry } from '@/utilities/cursor-registry';
 import { Logger } from '@/utilities/logger';
 import { type SelectionCursor, type SelectionState, SelectionType } from '@/utilities/selection';
 
@@ -26,7 +26,8 @@ const logger = new Logger( 'use-render-cursors' );
  */
 export function useRenderCursors(
 	overlayRef: MutableRefObject< HTMLElement | null >,
-	blockEditorDocument: Document | null
+	blockEditorDocument: Document | null,
+	cursorRegistry: CursorRegistry
 ) {
 	const renderCursorsRef = useRef< () => void >();
 
@@ -57,12 +58,18 @@ export function useRenderCursors(
 				isMe: user.userInfo.isMe,
 			} ) );
 
-			drawUserSelections( overlayRef.current, blockEditorDocument, userSelections, drawType );
+			drawUserSelections(
+				overlayRef.current,
+				blockEditorDocument,
+				userSelections,
+				drawType,
+				cursorRegistry
+			);
 		};
 
 		// Render cursors immediately when data changes
 		renderCursorsRef.current();
-	}, [ drawType, sortedUsers, overlayRef.current, blockEditorDocument ] );
+	}, [ drawType, sortedUsers, overlayRef.current, blockEditorDocument, cursorRegistry ] );
 
 	return renderCursorsRef;
 }
@@ -84,7 +91,8 @@ const drawUserSelections = (
 		color: string;
 		isMe: boolean;
 	}[],
-	drawType: DrawType
+	drawType: DrawType,
+	cursorRegistry: CursorRegistry
 ) => {
 	if ( ! overlay || ! editorDocument ) {
 		return;

--- a/src/utilities/cursor-registry.ts
+++ b/src/utilities/cursor-registry.ts
@@ -1,13 +1,3 @@
-/**
- * Cursor Registry - Singleton pattern
- *
- * This uses a singleton pattern instead of React Context because WordPress's Slot/Fill
- * implementation doesn't properly share Context between Fill components.
- *
- * EditorPresence and BlockCanvasCover.Fill appear to break Context propagation.
- * The singleton pattern works reliably across these boundaries.
- */
-
 interface ScrollToCursorOptions {
 	behavior?: ScrollBehavior;
 	block?: ScrollLogicalPosition;
@@ -16,31 +6,35 @@ interface ScrollToCursorOptions {
 }
 
 /**
- * Singleton cursor registry that stores references to cursor elements.
- * Uses arrow functions to preserve `this` binding when methods are destructured.
+ * Cursor Registry
+ * ===
+ * This registry stores references to cursor elements so that we can access them
+ * in different parts of the component tree. This would more ideally be solved
+ * with React context or state in the awareness store, but:
+ *
+ * 1. EditorPresence and BlockCanvasCover slot/fill break context propagation. We
+ *    don't currently have a way to provide context to both the slot and fill.
+ * 2. Storing pointers to the cursor elements in the awareness store might be a
+ *    better solution, but would require broader refactoring.
+ *
+ * For now, we create an instance of this registry in a React ref and pass it
+ * down to the components that need it.
  */
-class CursorRegistry {
+export class CursorRegistry {
 	private cursorMap: Map< number, HTMLElement > = new Map();
 
 	/**
 	 * Register a cursor element when it's created
 	 */
-	public registerCursor = ( clientId: number, element: HTMLElement ): void => {
+	public registerCursor( clientId: number, element: HTMLElement ): void {
 		this.cursorMap.set( clientId, element );
-	};
-
-	/**
-	 * Get a cursor element by clientId
-	 */
-	public getCursorElement = ( clientId: number ): HTMLElement | null => {
-		return this.cursorMap.get( clientId ) ?? null;
-	};
+	}
 
 	/**
 	 * Scroll to a cursor by clientId
 	 * @returns true if cursor was found and scrolled to, false otherwise
 	 */
-	public scrollToCursor = ( clientId: number, options?: ScrollToCursorOptions ): boolean => {
+	public scrollToCursor( clientId: number, options?: ScrollToCursorOptions ): boolean {
 		const cursorElement = this.cursorMap.get( clientId );
 
 		if ( ! cursorElement ) {
@@ -60,23 +54,23 @@ class CursorRegistry {
 		}
 
 		return true;
-	};
+	}
 
 	/**
 	 * Remove all cursor elements from DOM and clear the registry.
 	 * Uses stored refs instead of DOM queries for better performance.
 	 */
-	public removeAll = (): void => {
+	public removeAll(): void {
 		// Remove each cursor element using stored refs
 		this.cursorMap.forEach( element => element.remove() );
 		// Clear the registry
 		this.cursorMap.clear();
-	};
+	}
 
 	/**
 	 * Add a temporary highlight effect to the cursor
 	 */
-	private highlightCursor = ( element: HTMLElement, duration: number ): void => {
+	private highlightCursor( element: HTMLElement, duration: number ): void {
 		// Add highlight class
 		element.classList.add( 'vip-real-time-collaboration-cursor-highlighted' );
 
@@ -84,8 +78,5 @@ class CursorRegistry {
 		setTimeout( () => {
 			element.classList.remove( 'vip-real-time-collaboration-cursor-highlighted' );
 		}, duration );
-	};
+	}
 }
-
-// Export singleton instance
-export const cursorRegistry = new CursorRegistry();

--- a/src/utilities/cursor-registry.ts
+++ b/src/utilities/cursor-registry.ts
@@ -17,8 +17,9 @@ interface ScrollToCursorOptions {
  * 2. Storing pointers to the cursor elements in the awareness store might be a
  *    better solution, but would require broader refactoring.
  *
- * For now, we create an instance of this registry in a React ref and pass it
- * down to the components that need it.
+ * For now, we create a single instance of this registry and pass it down to the
+ * components that need it. It's important that we create a single instance and
+ * not a new instance per component or render; use useRef to accomplish this.
  */
 export class CursorRegistry {
 	private cursorMap: Map< number, HTMLElement > = new Map();


### PR DESCRIPTION
Previously, the `CursorRegistry` was positioned as React context (which it wasn't) and instantiated in the global scope. This global non-reactive state nearly always leads to issues down the road. 

Ideal reactive options are elusive:

- Refactor our cursor rendering as pure functional React components (complex).
- Wrap the entire block editor component tree in a real context provider (not possible?).
- Store pointers to cursor elements in the awareness store (moderately complex).

For now, we instantiate the `CursorRegistry` in the render loop using a ref to maintain references and describe the issue in a comment.