### PR TITLE
Support for collection syncing

### DIFF
--- a/inc/Auth/SyncPermissions.php
+++ b/inc/Auth/SyncPermissions.php
@@ -47,7 +47,7 @@ final class SyncPermissions {
 		[ $entity_kind, $entity_name ] = $parts;
 
 		// Handle post type entities
-		if ( 'postType' === $entity_kind ) {
+		if ( 'postType' === $entity_kind && 'collection' !== $sync_object_id ) {
 			/**
 			 * For post entities, we only need the sync object ID (post ID) for permission checking.
 			 * The entity_name is Gutenberg's entity name which maps to post type name instead of

--- a/inc/Auth/SyncPermissions.php
+++ b/inc/Auth/SyncPermissions.php
@@ -46,7 +46,7 @@ final class SyncPermissions {
 		// Extract Gutenberg entity kind and name from sync object type
 		[ $entity_kind, $entity_name ] = $parts;
 
-		// Handle post type entities
+		// Handle post type entities (not collections)
 		if ( 'postType' === $entity_kind && 'collection' !== $sync_object_id ) {
 			/**
 			 * For post entities, we only need the sync object ID (post ID) for permission checking.

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -176,13 +176,16 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 
 	return async function (
 		objectType: ObjectType,
-		objectId: ObjectID,
+		objectId: ObjectID | null,
 		doc: Y.Doc,
 		awareness?: Awareness
 	) {
 		try {
-			// For now, we only support traditional post types.
-			if ( ! objectType.startsWith( 'postType/' ) || ! parseInt( objectId, 10 ) ) {
+			// For now, we only support collections and traditional post types.
+			if (
+				null !== objectId &&
+				( ! objectType.startsWith( 'postType/' ) || ! parseInt( objectId, 10 ) )
+			) {
 				logger.debug( 'WebSocket connection skipped for unsupported object', {
 					objectType,
 					objectId,
@@ -198,10 +201,10 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 			 * multisite. We don't sync entities like those yet. When we do, we'll need to revisit
 			 * adding the blog ID to the room name as that won't be needed.
 			 */
-			const roomName = `site-${ BLOG_ID ?? 1 }/${ objectType }-${ objectId }`;
+			const roomName = `site-${ BLOG_ID ?? 1 }/${ objectType }-${ objectId ?? 'collection' }`;
 			const options = { ...config.options, awareness };
 			const provider = new WebsocketProvider( config.serverUrl, roomName, doc, options );
-			const connect = createConnect( provider, objectType, objectId );
+			const connect = createConnect( provider, objectType, objectId ?? 'collection' );
 
 			provider.on( 'connection-close', connect );
 			provider.on( 'connection-error', () => {


### PR DESCRIPTION
Support for collection syncing. Companion to https://github.com/WordPress/gutenberg/pull/73027

Allows for a connection representing a entity collection, with the magic string `collection` standing in for the object ID.