### PR TITLE
Skip unnecessary user entered notification

### DIFF
--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -107,6 +107,7 @@ export class AwarenessManager {
 			color: getNewUserColor( otherUserColors ),
 			isConnected: true,
 			isMe: true,
+			enteredAt: Date.now(),
 		};
 
 		this.setLocalStateField( 'userInfo', userInfo );

--- a/src/store/awareness-store.ts
+++ b/src/store/awareness-store.ts
@@ -22,6 +22,7 @@ export interface UserInfo extends WordPressUserInfo {
 	color: string;
 	isConnected: boolean;
 	isMe: boolean;
+	enteredAt: number;
 }
 
 export interface EditorState {
@@ -166,7 +167,16 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 				}
 			} else {
 				const { userInfo } = action.payload.userState;
-				sendNotification( NotificationType.UserEntered, userInfo );
+				const currentMeUser = Array.from( state.userMap.values() ).find(
+					user => user.userInfo.isMe && user.userInfo.isConnected
+				);
+
+				sendNotification(
+					NotificationType.UserEntered,
+					userInfo,
+					undefined,
+					currentMeUser?.userInfo
+				);
 			}
 
 			state.userMap.set( action.payload.clientId, action.payload.userState );

--- a/src/utilities/notifications.test.ts
+++ b/src/utilities/notifications.test.ts
@@ -14,6 +14,7 @@ const baseUserInfo: UserInfo = {
 	isConnected: true,
 	isMe: false,
 	email: 'alice@example.com',
+	enteredAt: Date.now(),
 };
 
 describe( 'notifications', () => {
@@ -243,6 +244,51 @@ describe( 'notifications', () => {
 					0,
 					'createNotice should not be called'
 				);
+			} );
+
+			it( 'current user just entered', () => {
+				const currentMeUserInfo = { ...baseUserInfo, isMe: true, enteredAt: Date.now() };
+				getSettingMock.mock.mockImplementationOnce( () => true );
+				sendNotification(
+					NotificationType.UserEntered,
+					baseUserInfo,
+					undefined,
+					currentMeUserInfo
+				);
+
+				assert.strictEqual(
+					createNoticeMock.mock.callCount(),
+					0,
+					'createNotice should not be called'
+				);
+				assert.strictEqual(
+					createNoticeMock.mock.calls.length,
+					0,
+					'createNotice should not be called'
+				);
+			} );
+
+			it( 'user to send about just entered before current user', () => {
+				const currentMeUserInfo = { ...baseUserInfo, isMe: true, enteredAt: Date.now() - 10000 };
+				getSettingMock.mock.mockImplementationOnce( () => true );
+				sendNotification(
+					NotificationType.UserEntered,
+					baseUserInfo,
+					undefined,
+					currentMeUserInfo
+				);
+
+				assert.strictEqual( createNoticeMock.mock.callCount(), 1, 'createNotice should be called' );
+				assert.strictEqual(
+					createNoticeMock.mock.calls.length,
+					1,
+					'createNotice should be called'
+				);
+				assert.deepStrictEqual( createNoticeMock.mock.calls[ 0 ]?.arguments, [
+					'info',
+					'Alice has entered the post.',
+					{ id: 'remote-user-user-entered-123', isDismissible: false, type: 'snackbar' },
+				] );
 			} );
 		} );
 

--- a/src/utilities/notifications.ts
+++ b/src/utilities/notifications.ts
@@ -51,7 +51,8 @@ function getUserPresenceNotificationContent( userInfo: UserInfo, type: Notificat
 function shouldSendNotification(
 	userInfo: UserInfo,
 	type: NotificationType,
-	content: string
+	content: string,
+	currentMeUserInfo?: UserInfo
 ): boolean {
 	// If content is empty, skip.
 	if ( ! content ) {
@@ -72,6 +73,15 @@ function shouldSendNotification(
 	if (
 		( type === NotificationType.UserEntered || type === NotificationType.UserExited ) &&
 		userInfo.isMe
+	) {
+		return false;
+	}
+
+	// The user has just recently entered or re-joined, and doesn't need to be told about the other collaborators.
+	if (
+		type === NotificationType.UserEntered &&
+		currentMeUserInfo &&
+		currentMeUserInfo.enteredAt > userInfo.enteredAt
 	) {
 		return false;
 	}
@@ -101,29 +111,31 @@ function getContentForNotificationType(
  *
  * Certain notifications can be skipped based on user settings, or scenarios.
  *
- * @param content the notification content
- * @param userInfo the user info of the user related to the notification
- * @param type the type of notification
+ * @param type The type of notification to send.
+ * @param userInfoToSendAbout The user info of the user related to the notification.
+ * @param status The status of the post (only relevant for PostUpdated notifications).
+ * @param currentMeUserInfo The user info of the current user (only relevant for user entered notifications).
  */
 export function sendNotification(
 	type: NotificationType,
-	userInfo: UserInfo,
-	status?: string
+	userInfoToSendAbout: UserInfo,
+	status?: string,
+	currentMeUserInfo?: UserInfo
 ): void {
 	// This is done on purpose, to allow tests to be written without noticesStore.
 	const { createNotice } = dispatch( noticesStore );
 
 	// Get the content for the notification type.
-	const content = getContentForNotificationType( userInfo, type, status );
+	const content = getContentForNotificationType( userInfoToSendAbout, type, status );
 
 	// Skip notifications for certain cases.
-	if ( ! shouldSendNotification( userInfo, type, content ) ) {
+	if ( ! shouldSendNotification( userInfoToSendAbout, type, content, currentMeUserInfo ) ) {
 		return;
 	}
 
 	// Send the notification, via a notice.
 	void createNotice( 'info', content, {
-		id: `${ type }-${ userInfo.clientId }`,
+		id: `${ type }-${ userInfoToSendAbout.clientId }`,
 		isDismissible: false,
 		type: 'snackbar',
 	} );


### PR DESCRIPTION
### Description

Currently, if a user enters an existing collaboration session they get a redundant notification for every collaborator already in the session. They don't need to know that, and that's a redundant notification. This changes that, by skipping notifying them of all the users already in the session.

### Why

This happens because Yjs informs the new client of every new client that's been added from the existing client pool. There isn't a "entered At" field for the user unfortunately. 

### How

This is fixed by adding a timestamp to every user that enters a collaboration session, in the order in which they joined. This timestamp is then compared with the current "me" user to figure out who should get the notification and who shouldn't.

This also works for page refreshes now.

### Testing

 - Open a post in a browser
 - In another browser, open the same post
 - The only notification should be in the first browser, of the user in the second browser joining.
 - Refresh either page, and only 1 notification should show up