### PR TITLE
Add collaboration mode picker for view and edit modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@wordpress/icons": "10.32.0",
         "@wordpress/notices": "5.32.0",
         "@wordpress/plugins": "^7.26.0",
+        "@wordpress/primitives": "4.35.0",
         "@wordpress/private-apis": "^1.33.0",
         "@wordpress/scripts": "30.25.0",
         "@wordpress/sync": "1.32.0",
@@ -8705,15 +8706,15 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.33.0.tgz",
-      "integrity": "sha512-vUcH12viRpHkqZ1j3kEqE3bnCvl0tsvUUgp9USgeqRx9YE+8XAn6MdghvwF65/R2It66vqogJlKnbO4wfXehTA==",
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.35.0.tgz",
+      "integrity": "sha512-RmxQsk0ANoHtxDc6anbUH/lHL7Mmbbdn016WKHYVh4+79EzN1tBeM8OML2gHpllUISmIYQvO4wIPSmEVzRh+Gw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/escape-html": "^3.35.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8786,9 +8787,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
-      "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.35.0.tgz",
+      "integrity": "sha512-thY7RGAI6UijG3sbBm4IRzMX9lnHkEA/vR3Y0E5BGQYzNFwc+i7t1Lm4scpEBnL3UEQxdlD1wiJTH4pv5olV+Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -9734,13 +9735,13 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.33.0.tgz",
-      "integrity": "sha512-gK5/L+Yz5JmsJBwFd/pMb4zQoOYkhNkMAdhFCm9akn/qG/zrP+UlligxNYVbC+HhgOT6Jg932gcu2KqWkEYoSw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.35.0.tgz",
+      "integrity": "sha512-F7FqOM9tkgwc0DwFqsgtOcvREJgBHALbCBFwv1kmxRadknD6YsBdmpamceN2UIHi9NnOM0Gruo2vJNKjoN4bEw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.33.0",
+        "@wordpress/element": "^6.35.0",
         "clsx": "^2.1.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@wordpress/icons": "10.32.0",
     "@wordpress/notices": "5.32.0",
     "@wordpress/plugins": "^7.26.0",
+    "@wordpress/primitives": "4.35.0",
     "@wordpress/private-apis": "^1.33.0",
     "@wordpress/scripts": "30.25.0",
     "@wordpress/sync": "1.32.0",

--- a/src/components/collaboration-mode/collaboration-mode-picker.scss
+++ b/src/components/collaboration-mode/collaboration-mode-picker.scss
@@ -1,0 +1,93 @@
+.vip-collaboration-mode-button.has-icon {
+	color: #fff;
+	width: 32px;
+	height: 32px;
+	min-width: 32px;
+}
+
+.vip-collaboration-mode-popover.components-popover .components-popover__content {
+	padding: 0;
+	border-radius: 8px;
+	box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.05);
+	border: 1px solid #ddd;
+	min-width: 312px;
+	background: #ffffff;
+}
+
+.vip-collaboration-mode-menu {
+	display: flex;
+	flex-direction: column;
+	padding: 9px;
+	gap: 2px;
+	min-width: 312px;
+	border-radius: 8px;
+}
+
+.vip-collaboration-mode-menu-item {
+	// Reset button styles
+	all: unset;
+	box-sizing: border-box;
+
+	// Layout styles
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	padding: 8px 12px;
+	gap: 8px;
+	border-radius: 2px;
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+
+	&:hover:not(.is-selected) {
+		background-color: #f0f0f0;
+	}
+
+	&.is-selected {
+		background: #3858e9;
+
+		svg {
+			color: #ffffff;
+		}
+
+		.vip-collaboration-mode-menu-item-label {
+			.vip-collaboration-mode-menu-item-title, .vip-collaboration-mode-menu-item-description {
+				color: #ffffff;
+			}
+		}
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--wp-admin-theme-color, #007cba);
+		outline-offset: -2px;
+	}
+
+	svg {
+		color: #757575;
+		fill: currentColor;
+	}
+
+	.vip-collaboration-mode-menu-item-label {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		flex: 1;
+	
+		.vip-collaboration-mode-menu-item-title {
+			font-size: 13px;
+			line-height: 20px;
+			color: #1e1e1e;
+		}
+		
+		.vip-collaboration-mode-menu-item-description {
+			font-size: 12px;
+			line-height: 16px;
+			color: #757575;
+		}
+	}
+}
+
+.vip-collaboration-mode-menu-item-content {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+}

--- a/src/components/collaboration-mode/collaboration-mode-picker.tsx
+++ b/src/components/collaboration-mode/collaboration-mode-picker.tsx
@@ -1,6 +1,7 @@
 import { Button, Popover, Icon } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { paragraph } from '@wordpress/icons';
 
 import { viewIcon } from './view-icon';
@@ -23,14 +24,14 @@ interface ModeOption {
 const MODES: ModeOption[] = [
 	{
 		value: CollaborationMode.EDIT,
-		label: 'Edit',
-		description: 'Make changes',
+		label: __( 'Edit', 'vip-real-time-collaboration' ),
+		description: __( 'Make changes', 'vip-real-time-collaboration' ),
 		icon: paragraph,
 	},
 	{
 		value: CollaborationMode.VIEW,
-		label: 'View',
-		description: 'Focus on content',
+		label: __( 'View', 'vip-real-time-collaboration' ),
+		description: __( 'Focus on content', 'vip-real-time-collaboration' ),
 		icon: viewIcon,
 	},
 ];
@@ -69,6 +70,7 @@ export function CollaborationModePicker() {
 				icon={ currentIcon }
 				ref={ setPopoverAnchor }
 				iconSize={ 24 }
+				label={ __( 'Collaboration mode', 'vip-real-time-collaboration' ) }
 			/>
 			{ isPopoverVisible && (
 				<Popover

--- a/src/components/collaboration-mode/collaboration-mode-picker.tsx
+++ b/src/components/collaboration-mode/collaboration-mode-picker.tsx
@@ -1,0 +1,101 @@
+import { Button, Popover, Icon } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { paragraph } from '@wordpress/icons';
+
+import { viewIcon } from './view-icon';
+
+import '@/components/collaboration-mode/collaboration-mode-picker.scss';
+
+type CollaborationModeType = 'view' | 'edit';
+
+interface ModeOption {
+	value: CollaborationModeType;
+	label: string;
+	description: string;
+	icon: JSX.Element;
+}
+
+const MODES: ModeOption[] = [
+	{
+		value: 'view',
+		label: 'View',
+		description: 'Focus on content',
+		icon: viewIcon,
+	},
+	{
+		value: 'edit',
+		label: 'Edit',
+		description: 'Make changes',
+		icon: paragraph,
+	},
+];
+
+/**
+ * CollaborationModePicker component that allows users to switch between View and Edit modes.
+ * Displays the currently selected mode icon in the toolbar and opens a popover to select a different mode.
+ */
+export function CollaborationModePicker() {
+	const [ selectedMode, setSelectedMode ] = useState< CollaborationModeType >( 'edit' );
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >( null );
+
+	const currentMode = MODES.find( mode => mode.value === selectedMode );
+	const currentIcon = currentMode?.icon || paragraph;
+
+	const handleModeSelect = ( mode: CollaborationModeType ) => {
+		setSelectedMode( mode );
+		setIsPopoverVisible( false );
+	};
+
+	return (
+		<>
+			<Button
+				className="vip-collaboration-mode-button"
+				variant="primary"
+				aria-label={ `Collaboration mode: ${ currentMode?.label }` }
+				onClick={ () => setIsPopoverVisible( ! isPopoverVisible ) }
+				isPressed={ isPopoverVisible }
+				icon={ currentIcon }
+				ref={ setPopoverAnchor }
+				iconSize={ 24 }
+			/>
+			{ isPopoverVisible && (
+				<Popover
+					anchor={ popoverAnchor }
+					placement="bottom-start"
+					offset={ 10 }
+					className="vip-collaboration-mode-popover"
+					onClose={ () => setIsPopoverVisible( false ) }
+				>
+					<div className="vip-collaboration-mode-menu">
+						{ MODES.map( ( { value, label, description, icon } ) => {
+							const isSelected = value === selectedMode;
+							return (
+								<button
+									key={ value }
+									className={ `vip-collaboration-mode-menu-item ${
+										isSelected ? 'is-selected' : ''
+									}` }
+									onClick={ () => handleModeSelect( value ) }
+									aria-pressed={ isSelected }
+								>
+									<div className="vip-collaboration-mode-menu-item-content">
+										<div className="vip-collaboration-mode-menu-item-icon">
+											<Icon icon={ icon } size={ 24 } />
+										</div>
+										<div className="vip-collaboration-mode-menu-item-label">
+											<div className="vip-collaboration-mode-menu-item-title">{ label }</div>
+											<div className="vip-collaboration-mode-menu-item-description">
+												{ description }
+											</div>
+										</div>
+									</div>
+								</button>
+							);
+						} ) }
+					</div>
+				</Popover>
+			) }
+		</>
+	);
+}

--- a/src/components/collaboration-mode/collaboration-mode-picker.tsx
+++ b/src/components/collaboration-mode/collaboration-mode-picker.tsx
@@ -1,15 +1,20 @@
 import { Button, Popover, Icon } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { paragraph } from '@wordpress/icons';
 
 import { viewIcon } from './view-icon';
+import {
+	store as collaborationModeStore,
+	type CollaborationModeStoreSelectors,
+	type CollaborationModeStoreActions,
+} from '@/store/collaboration-mode-store';
+import { CollaborationMode } from '@/types/collaboration-mode';
 
 import '@/components/collaboration-mode/collaboration-mode-picker.scss';
 
-type CollaborationModeType = 'view' | 'edit';
-
 interface ModeOption {
-	value: CollaborationModeType;
+	value: CollaborationMode;
 	label: string;
 	description: string;
 	icon: JSX.Element;
@@ -17,16 +22,16 @@ interface ModeOption {
 
 const MODES: ModeOption[] = [
 	{
-		value: 'view',
-		label: 'View',
-		description: 'Focus on content',
-		icon: viewIcon,
-	},
-	{
-		value: 'edit',
+		value: CollaborationMode.EDIT,
 		label: 'Edit',
 		description: 'Make changes',
 		icon: paragraph,
+	},
+	{
+		value: CollaborationMode.VIEW,
+		label: 'View',
+		description: 'Focus on content',
+		icon: viewIcon,
 	},
 ];
 
@@ -35,15 +40,21 @@ const MODES: ModeOption[] = [
  * Displays the currently selected mode icon in the toolbar and opens a popover to select a different mode.
  */
 export function CollaborationModePicker() {
-	const [ selectedMode, setSelectedMode ] = useState< CollaborationModeType >( 'edit' );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >( null );
+
+	const selectedMode = useSelect< CollaborationModeStoreSelectors, CollaborationMode >(
+		select => select( collaborationModeStore ).getMode(),
+		[]
+	);
+
+	const { setMode } = useDispatch< CollaborationModeStoreActions >( collaborationModeStore );
 
 	const currentMode = MODES.find( mode => mode.value === selectedMode );
 	const currentIcon = currentMode?.icon || paragraph;
 
-	const handleModeSelect = ( mode: CollaborationModeType ) => {
-		setSelectedMode( mode );
+	const handleModeSelect = ( mode: CollaborationMode ) => {
+		setMode( mode );
 		setIsPopoverVisible( false );
 	};
 

--- a/src/components/collaboration-mode/view-icon.tsx
+++ b/src/components/collaboration-mode/view-icon.tsx
@@ -1,0 +1,13 @@
+import { SVG, Path } from '@wordpress/primitives';
+
+export const viewIcon = (
+	<SVG viewBox="0 0 24 24">
+		<Path
+			stroke="currentColor"
+			strokeWidth="1.5"
+			fill="var(--background-color, transparent)"
+			d="M12.502 8.58241C12.2806 8.61797 12.0499 8.65723 11.8138 8.70087C11.0556 8.84102 10.2285 9.02654 9.47419 9.26761C8.73595 9.50358 7.99801 9.81375 7.47005 10.2338C6.96282 10.6375 6.47066 11.2479 6.03151 11.8837C5.58458 12.5307 5.15861 13.254 4.79216 13.9239C4.67072 14.1459 4.55556 14.3638 4.44736 14.5717L1.17885 1.60744L12.502 8.58241Z"
+			transform="translate(5, 4)"
+		/>
+	</SVG>
+);

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -126,7 +126,7 @@ export function RTCSettingsPanel() {
 							/>
 
 							<ToggleControl
-								label="Enable collaboration modes"
+								label={ __( 'Enable collaboration modes', 'vip-real-time-collaboration' ) }
 								checked={ isCollaborationModePickerEnabled }
 								onChange={ ( enabled: boolean ) =>
 									setSetting( Setting.COLLABORATION_MODE_PICKER, enabled )

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -36,6 +36,7 @@ export function RTCSettingsPanel() {
 		isPostUpdateNotificationEnabled,
 		isUserEnterNotificationEnabled,
 		isUserExitNotificationEnabled,
+		isCollaborationModePickerEnabled,
 	} = useSelect<
 		SettingsStoreSelectors,
 		{
@@ -46,6 +47,7 @@ export function RTCSettingsPanel() {
 			isPostUpdateNotificationEnabled: boolean;
 			isUserEnterNotificationEnabled: boolean;
 			isUserExitNotificationEnabled: boolean;
+			isCollaborationModePickerEnabled: boolean;
 		}
 	>( select => {
 		const { getSetting } = select( rtcSettingsStore );
@@ -57,6 +59,7 @@ export function RTCSettingsPanel() {
 			isPostUpdateNotificationEnabled: getSetting( Setting.POST_UPDATE_NOTIFICATION ),
 			isUserEnterNotificationEnabled: getSetting( Setting.USER_ENTER_NOTIFICATION ),
 			isUserExitNotificationEnabled: getSetting( Setting.USER_EXIT_NOTIFICATION ),
+			isCollaborationModePickerEnabled: getSetting( Setting.COLLABORATION_MODE_PICKER ),
 		};
 	}, [] );
 
@@ -68,9 +71,11 @@ export function RTCSettingsPanel() {
 
 	return (
 		<>
-			<CollaborationMode>
-				<CollaborationModePicker />
-			</CollaborationMode>
+			{ isCollaborationModePickerEnabled && (
+				<CollaborationMode>
+					<CollaborationModePicker />
+				</CollaborationMode>
+			) }
 			{ isAvatarsEnabled && (
 				<EditorPresence>
 					<Avatars cursorRegistry={ cursorRegistry.current } />
@@ -113,11 +118,21 @@ export function RTCSettingsPanel() {
 					/>
 
 					{ isDevelopment() && (
-						<ToggleControl
-							label="Show debug tools"
-							checked={ isDebugToolsEnabled }
-							onChange={ ( enabled: boolean ) => setSetting( Setting.DEBUG_TOOLS, enabled ) }
-						/>
+						<>
+							<ToggleControl
+								label="Show debug tools"
+								checked={ isDebugToolsEnabled }
+								onChange={ ( enabled: boolean ) => setSetting( Setting.DEBUG_TOOLS, enabled ) }
+							/>
+
+							<ToggleControl
+								label="Enable collaboration modes"
+								checked={ isCollaborationModePickerEnabled }
+								onChange={ ( enabled: boolean ) =>
+									setSetting( Setting.COLLABORATION_MODE_PICKER, enabled )
+								}
+							/>
+						</>
 					) }
 
 					<Heading level={ 3 } style={ { marginTop: '24px' } }>

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
 import { Avatars } from './avatars';
+import { CollaborationModePicker } from './collaboration-mode/collaboration-mode-picker';
 import { DebugTools } from './debug-tools';
 import { PostLockedModal } from './post-locked-modal';
 import { RTCOverlay } from './rtc-overlay';
@@ -24,7 +25,7 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'@wordpress/editor'
 );
 
-const { EditorPresence } = unlock( editorPrivateApis );
+const { EditorPresence, CollaborationMode } = unlock( editorPrivateApis );
 
 export function RTCSettingsPanel() {
 	const {
@@ -67,6 +68,9 @@ export function RTCSettingsPanel() {
 
 	return (
 		<>
+			<CollaborationMode>
+				<CollaborationModePicker />
+			</CollaborationMode>
 			{ isAvatarsEnabled && (
 				<EditorPresence>
 					<Avatars cursorRegistry={ cursorRegistry.current } />

--- a/src/store/collaboration-mode-store.ts
+++ b/src/store/collaboration-mode-store.ts
@@ -1,0 +1,67 @@
+import { register, createReduxStore, StoreDescriptor } from '@wordpress/data';
+
+import { CollaborationMode } from '@/types/collaboration-mode';
+
+const STORE_NAME = 'vip-real-time-collaboration/collaboration-mode';
+
+interface CollaborationModeState {
+	currentMode: CollaborationMode;
+}
+
+const DEFAULT_STATE: CollaborationModeState = {
+	currentMode: CollaborationMode.EDIT,
+};
+
+const actions = {
+	setMode: ( mode: CollaborationMode ): CollaborationModeAction => ( {
+		type: 'SET_MODE',
+		payload: { mode },
+	} ),
+};
+
+const reducer = (
+	state = DEFAULT_STATE,
+	action: CollaborationModeAction
+): CollaborationModeState => {
+	switch ( action.type ) {
+		case 'SET_MODE': {
+			return {
+				...state,
+				currentMode: action.payload.mode,
+			};
+		}
+		default:
+			return state;
+	}
+};
+
+const selectors = {
+	getMode( state: CollaborationModeState ): CollaborationMode {
+		return state.currentMode;
+	},
+};
+
+type CollaborationModeAction = {
+	type: 'SET_MODE';
+	payload: {
+		mode: CollaborationMode;
+	};
+};
+
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+( register as ( store: StoreDescriptor ) => void )( store );
+
+export type { CollaborationModeState };
+
+export type CollaborationModeStoreActions = {
+	setMode: ( mode: CollaborationMode ) => void;
+};
+
+export type CollaborationModeStoreSelectors = {
+	getMode: () => CollaborationMode;
+};

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -14,6 +14,7 @@ export enum Setting {
 	POST_UPDATE_NOTIFICATION = 'Post_Update_Notification',
 	USER_ENTER_NOTIFICATION = 'User_Enter_Notification',
 	USER_EXIT_NOTIFICATION = 'User_Exit_Notification',
+	COLLABORATION_MODE_PICKER = 'Collaboration_Mode_Picker',
 }
 
 interface SettingsState {
@@ -24,6 +25,7 @@ interface SettingsState {
 	[ Setting.POST_UPDATE_NOTIFICATION ]: boolean;
 	[ Setting.USER_ENTER_NOTIFICATION ]: boolean;
 	[ Setting.USER_EXIT_NOTIFICATION ]: boolean;
+	[ Setting.COLLABORATION_MODE_PICKER ]: boolean;
 }
 
 const DEFAULT_STATE: SettingsState = {
@@ -34,7 +36,11 @@ const DEFAULT_STATE: SettingsState = {
 	[ Setting.POST_UPDATE_NOTIFICATION ]: true,
 	[ Setting.USER_ENTER_NOTIFICATION ]: true,
 	[ Setting.USER_EXIT_NOTIFICATION ]: false,
+	[ Setting.COLLABORATION_MODE_PICKER ]: false,
 };
+
+// Settings that are only available in development mode
+const DEV_ONLY_SETTINGS: Setting[] = [ Setting.DEBUG_TOOLS, Setting.COLLABORATION_MODE_PICKER ];
 
 const actions = {
 	setSetting: ( setting: Setting, enabled: boolean ): SettingsAction => ( {
@@ -64,8 +70,8 @@ const reducer = (
 
 const selectors = {
 	getSetting( state: SettingsState, setting: Setting ): boolean {
-		// Special handling for debug tools - only available in development
-		if ( setting === Setting.DEBUG_TOOLS ) {
+		// Special handling for dev-only settings
+		if ( DEV_ONLY_SETTINGS.includes( setting ) ) {
 			return isDevelopment() ? state[ setting ] : false;
 		}
 		return state[ setting ];

--- a/src/types/collaboration-mode.ts
+++ b/src/types/collaboration-mode.ts
@@ -1,0 +1,9 @@
+/**
+ * Collaboration mode types for the editor.
+ * - VIEW: Read-only mode, user can view content but not make edits
+ * - EDIT: Full editing mode, user can make changes to the content
+ */
+export enum CollaborationMode {
+	VIEW = 'view',
+	EDIT = 'edit',
+}

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -10,6 +10,7 @@ declare module '@wordpress/editor' {
 
 	export interface EditorPrivateApis {
 		EditorPresence: React.FC< React.PropsWithChildren >;
+		CollaborationMode: React.FC< React.PropsWithChildren >;
 	}
 
 	export const privateApis: PrivateApis< EditorPrivateApis >;


### PR DESCRIPTION
## Description

Adds a new collaboration mode picker component in the editor toolbar that lets users switch between View mode and Edit mode.

Currently its just an UI without any functionality.

Depends on gutenberg PR - https://github.com/WordPress/gutenberg/pull/73196

## Screenshots

| <img width="1180" height="504" alt="Screenshot 2025-11-13 at 12 48 38 AM" src="https://github.com/user-attachments/assets/ee199f8b-3a5f-49ba-a13d-6cbf68f0f848" /> |
| :----: |
| Collaboration mode picker expanded |

### Screen Recording

https://github.com/user-attachments/assets/6f471770-44dd-4fb4-ac88-0bdd4029d707