### PR TITLE
[VIP-2463] Add debug data export button to settings panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/wordpress__block-editor": "^14.21.0",
         "@wordpress/a11y": "4.34.0",
         "@wordpress/api-fetch": "7.32.0",
+        "@wordpress/blob": "4.35.0",
         "@wordpress/block-editor": "^15.5.0",
         "@wordpress/blocks": "^15.0.0",
         "@wordpress/components": "^30.3.0",
@@ -44,6 +45,7 @@
         "husky": "9.1.7",
         "lint-staged": "16.2.0",
         "prettier": "npm:wp-prettier@2.8.5",
+        "safe-stringify": "1.2.0",
         "ts-loader": "9.5.2",
         "typescript": "5.9.2",
         "yjs": "13.6.27"
@@ -7142,9 +7144,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.33.0.tgz",
-      "integrity": "sha512-ZgrzNRsSyi5tpOBhHlmjd4131PTKH7E+1z9BF3eeyo+3nQAvkTU1hdHQ7yJpbF/7Ss1FeTjF+qvKoB25p9c1/w==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.35.0.tgz",
+      "integrity": "sha512-8b+A6in2dH+PPhGGI84GwNPyi8mxXUgsTsBG9Ey/WCYRFWXJmqhkgTUnZIi4PvieJbmmAILI9oyfMPSfeAb0sg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -25069,6 +25071,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-stringify/-/safe-stringify-1.2.0.tgz",
+      "integrity": "sha512-C+LbapLbyGhP/WeMTrnYhIPjUoNTXZ/A3Znli8D5iF+IZXrDlgvfruykOq/bZ/5ncGy/K6RsavHlkirgWDFNdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/wordpress__block-editor": "^14.21.0",
     "@wordpress/a11y": "4.34.0",
     "@wordpress/api-fetch": "7.32.0",
+    "@wordpress/blob": "4.35.0",
     "@wordpress/block-editor": "^15.5.0",
     "@wordpress/blocks": "^15.0.0",
     "@wordpress/components": "^30.3.0",
@@ -83,6 +84,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.2.0",
     "prettier": "npm:wp-prettier@2.8.5",
+    "safe-stringify": "1.2.0",
     "ts-loader": "9.5.2",
     "typescript": "5.9.2",
     "yjs": "13.6.27"

--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -134,9 +134,8 @@ export class AwarenessManager {
 	}
 
 	public static getDebugData(): YDocDebugData | null {
-		const logger = new Logger( 'awareness-manager' );
 		if ( ! AwarenessManager.__instance?.awareness?.doc ) {
-			logger.error( 'getDebugData() awareness document not found' );
+			AwarenessManager.__instance.logger.error( 'getDebugData() awareness document not found' );
 			return null;
 		}
 

--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -47,9 +47,36 @@ interface AwarenessStateChange {
 	removed: AwarenessClientID[];
 }
 
+// Type for serializable left/right item references to avoid deep nesting
+type SerializableYItemRef = Pick< Y.Item, 'id' | 'length' | 'origin' | 'content' >;
+
+// Serializable Y.Item - only includes data properties with shallow left/right references
+type SerializableYItem = Pick<
+	Y.Item,
+	| 'id'
+	| 'length'
+	| 'origin'
+	| 'rightOrigin'
+	| 'parent'
+	| 'parentSub'
+	| 'redone'
+	| 'content'
+	| 'info'
+> & {
+	left: SerializableYItemRef | null;
+	right: SerializableYItemRef | null;
+};
+
 interface YDocDebugData {
 	doc: Record< string, unknown >;
-	clients: Map< number, unknown >;
+	clients: Record< number, Array< SerializableYItem > >;
+}
+
+/**
+ * Type guard to check if a struct is a Y.Item (not Y.GC)
+ */
+function isYItem( struct: Y.Item | Y.GC ): struct is Y.Item {
+	return 'content' in struct;
 }
 
 export class AwarenessManager {
@@ -113,9 +140,32 @@ export class AwarenessManager {
 			docData[ key ] = value.toJSON();
 		} );
 
+		// Serialize Yjs client items to avoid deep nesting
+		const serializableClientItems: Record< number, Array< SerializableYItem > > = {};
+
+		ydoc.store.clients.forEach( ( structs, clientId ) => {
+			// Filter for Y.Item only (skip Y.GC garbage collection structs)
+			const items = structs.filter( isYItem );
+
+			// eslint-disable-next-line security/detect-object-injection -- clientId is a number from Yjs, not user input
+			serializableClientItems[ clientId ] = items.map( item => {
+				const { left, right, ...rest } = item;
+
+				return {
+					...rest,
+					left: left
+						? { id: left.id, length: left.length, origin: left.origin, content: left.content }
+						: null,
+					right: right
+						? { id: right.id, length: right.length, origin: right.origin, content: right.content }
+						: null,
+				};
+			} );
+		} );
+
 		return {
 			doc: docData,
-			clients: ydoc.store.clients,
+			clients: serializableClientItems,
 		};
 	}
 
@@ -137,6 +187,39 @@ export class AwarenessManager {
 		};
 
 		this.setLocalStateField( 'userInfo', userInfo );
+
+		// Persist Yjs client ID to WordPress user mapping in the YDoc
+		// This ensures the mapping is synced and available even after users disconnect
+		this.persistUserClientsMap( this.awareness.clientID, userInfo );
+	}
+
+	/**
+	 * Persist a user client mapping in the YDoc.
+	 * Stores Yjs client ID -> WordPress user info mapping for debugging.
+	 */
+	private persistUserClientsMap( yjsClientId: number, userInfo: UserInfo ): void {
+		const stateMap = this.awareness.doc.getMap( 'state' );
+		let clientWpUserMap = stateMap.get( 'clientWpUserMap' ) as
+			| Y.Map< Y.Map< unknown > >
+			| undefined;
+
+		if ( ! clientWpUserMap ) {
+			clientWpUserMap = new Y.Map< Y.Map< unknown > >();
+			stateMap.set( 'clientWpUserMap', clientWpUserMap );
+		}
+
+		// Check if this client is already persisted to avoid unnecessary CRDT operations
+		const clientKey = String( yjsClientId );
+		if ( clientWpUserMap.has( clientKey ) ) {
+			return;
+		}
+
+		// Store the mapping as an object for consistency with exported format
+		const userClientMap = new Y.Map< unknown >();
+		userClientMap.set( 'wpUserId', userInfo.id );
+		userClientMap.set( 'name', userInfo.name );
+		userClientMap.set( 'email', userInfo.email );
+		clientWpUserMap.set( clientKey, userClientMap );
 	}
 
 	/**
@@ -352,6 +435,9 @@ export class AwarenessManager {
 				userState.userInfo.isMe = false;
 
 				void upsertUser( id, userState );
+
+				// Persist remote user mapping to YDoc for debugging
+				this.persistUserClientsMap( id, userState.userInfo );
 			} );
 
 			removed.forEach( id => {

--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -133,10 +133,10 @@ export class AwarenessManager {
 		);
 	}
 
-	public static getDebugData(): YDocDebugData | null {
+	public static getDebugData(): YDocDebugData {
 		if ( ! AwarenessManager.__instance?.awareness?.doc ) {
 			AwarenessManager.__instance.logger.error( 'getDebugData() awareness document not found' );
-			return null;
+			return { doc: {}, clients: {}, userMap: {} };
 		}
 
 		const ydoc = AwarenessManager.__instance.awareness.doc;

--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -67,9 +67,17 @@ type SerializableYItem = Pick<
 	right: SerializableYItemRef | null;
 };
 
+// WordPress user info for debug export (subset of UserInfo from awareness-store)
+interface WpUserData {
+	wpUserId: number;
+	name: string;
+	email: string;
+}
+
 interface YDocDebugData {
 	doc: Record< string, unknown >;
 	clients: Record< number, Array< SerializableYItem > >;
+	userMap: Record< string, WpUserData >;
 }
 
 /**
@@ -140,6 +148,19 @@ export class AwarenessManager {
 			docData[ key ] = value.toJSON();
 		} );
 
+		// Build userMap from awareness store (all users seen this session)
+		const { getSeenUsers } = select( awarenessStore );
+		const allSeenUsers = getSeenUsers(); // Returns userMap with all seen users
+		const userMapData = new Map< string, WpUserData >();
+
+		allSeenUsers.forEach( ( userState, clientId ) => {
+			userMapData.set( String( clientId ), {
+				wpUserId: userState.userInfo.id,
+				name: userState.userInfo.name,
+				email: userState.userInfo.email,
+			} );
+		} );
+
 		// Serialize Yjs client items to avoid deep nesting
 		const serializableClientItems: Record< number, Array< SerializableYItem > > = {};
 
@@ -166,6 +187,7 @@ export class AwarenessManager {
 		return {
 			doc: docData,
 			clients: serializableClientItems,
+			userMap: Object.fromEntries( userMapData ),
 		};
 	}
 
@@ -187,39 +209,6 @@ export class AwarenessManager {
 		};
 
 		this.setLocalStateField( 'userInfo', userInfo );
-
-		// Persist Yjs client ID to WordPress user mapping in the YDoc
-		// This ensures the mapping is synced and available even after users disconnect
-		this.persistUserClientsMap( this.awareness.clientID, userInfo );
-	}
-
-	/**
-	 * Persist a user client mapping in the YDoc.
-	 * Stores Yjs client ID -> WordPress user info mapping for debugging.
-	 */
-	private persistUserClientsMap( yjsClientId: number, userInfo: UserInfo ): void {
-		const stateMap = this.awareness.doc.getMap( 'state' );
-		let clientWpUserMap = stateMap.get( 'clientWpUserMap' ) as
-			| Y.Map< Y.Map< unknown > >
-			| undefined;
-
-		if ( ! clientWpUserMap ) {
-			clientWpUserMap = new Y.Map< Y.Map< unknown > >();
-			stateMap.set( 'clientWpUserMap', clientWpUserMap );
-		}
-
-		// Check if this client is already persisted to avoid unnecessary CRDT operations
-		const clientKey = String( yjsClientId );
-		if ( clientWpUserMap.has( clientKey ) ) {
-			return;
-		}
-
-		// Store the mapping as an object for consistency with exported format
-		const userClientMap = new Y.Map< unknown >();
-		userClientMap.set( 'wpUserId', userInfo.id );
-		userClientMap.set( 'name', userInfo.name );
-		userClientMap.set( 'email', userInfo.email );
-		clientWpUserMap.set( clientKey, userClientMap );
 	}
 
 	/**
@@ -435,9 +424,6 @@ export class AwarenessManager {
 				userState.userInfo.isMe = false;
 
 				void upsertUser( id, userState );
-
-				// Persist remote user mapping to YDoc for debugging
-				this.persistUserClientsMap( id, userState.userInfo );
 			} );
 
 			removed.forEach( id => {

--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -47,6 +47,11 @@ interface AwarenessStateChange {
 	removed: AwarenessClientID[];
 }
 
+interface YDocDebugData {
+	doc: Record< string, unknown >;
+	clients: Map< number, unknown >;
+}
+
 export class AwarenessManager {
 	private static __instance: AwarenessManager;
 	private logger: Logger = new Logger( 'awareness-manager' );
@@ -93,14 +98,25 @@ export class AwarenessManager {
 		);
 	}
 
-	public static getYDocClients(): Map< number, unknown > | null {
+	public static getDebugData(): YDocDebugData | null {
 		const logger = new Logger( 'awareness-manager' );
 		if ( ! AwarenessManager.__instance?.awareness?.doc ) {
-			logger.error( 'getYDocClients() awareness document not found' );
+			logger.error( 'getDebugData() awareness document not found' );
 			return null;
 		}
 
-		return AwarenessManager.__instance.awareness.doc.store.clients;
+		const ydoc = AwarenessManager.__instance.awareness.doc;
+
+		// Manually extract doc data to avoid deprecated toJSON method
+		const docData: Record< string, unknown > = {};
+		ydoc.share.forEach( ( value, key ) => {
+			docData[ key ] = value.toJSON();
+		} );
+
+		return {
+			doc: docData,
+			clients: ydoc.store.clients,
+		};
 	}
 
 	private setCurrentUserState(): void {

--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -142,10 +142,9 @@ export class AwarenessManager {
 		const ydoc = AwarenessManager.__instance.awareness.doc;
 
 		// Manually extract doc data to avoid deprecated toJSON method
-		const docData: Record< string, unknown > = {};
-		ydoc.share.forEach( ( value, key ) => {
-			docData[ key ] = value.toJSON();
-		} );
+		const docData: Record< string, unknown > = Object.fromEntries(
+			Array.from( ydoc.share, ( [ key, value ] ) => [ key, value.toJSON() ] )
+		);
 
 		// Build userMap from awareness store (all users seen this session)
 		const { getSeenUsers } = select( awarenessStore );

--- a/src/awareness-manager.ts
+++ b/src/awareness-manager.ts
@@ -93,6 +93,16 @@ export class AwarenessManager {
 		);
 	}
 
+	public static getYDocClients(): Map< number, unknown > | null {
+		const logger = new Logger( 'awareness-manager' );
+		if ( ! AwarenessManager.__instance?.awareness?.doc ) {
+			logger.error( 'getYDocClients() awareness document not found' );
+			return null;
+		}
+
+		return AwarenessManager.__instance.awareness.doc.store.clients;
+	}
+
 	private setCurrentUserState(): void {
 		const states = this.getStates();
 		const otherUserColors = Array.from( states.values() )

--- a/src/components/debug-data-export-button.tsx
+++ b/src/components/debug-data-export-button.tsx
@@ -16,7 +16,7 @@ export function DebugDataExportButton() {
 		const jsonData = safeStringify(
 			{
 				doc: debugData.doc,
-				clients: Object.fromEntries( debugData.clients ),
+				clients: debugData.clients,
 			},
 			{ indentation: 2 }
 		);

--- a/src/components/debug-data-export-button.tsx
+++ b/src/components/debug-data-export-button.tsx
@@ -21,11 +21,7 @@ const handleDebugDataDownload = () => {
 
 export function DebugDataExportButton() {
 	return (
-		<Button
-			variant="secondary"
-			onClick={ handleDebugDataDownload }
-			style={ { width: '100%', marginTop: '8px' } }
-		>
+		<Button onClick={ handleDebugDataDownload } variant="secondary">
 			{ __( 'Export Debug Data', 'vip-real-time-collaboration' ) }
 		</Button>
 	);

--- a/src/components/debug-data-export-button.tsx
+++ b/src/components/debug-data-export-button.tsx
@@ -1,0 +1,31 @@
+import { downloadBlob } from '@wordpress/blob';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import safeStringify from 'safe-stringify';
+
+import { AwarenessManager } from '@/awareness-manager';
+
+export function DebugDataExportButton() {
+	const handleDownload = () => {
+		const clients = AwarenessManager.getYDocClients();
+		if ( ! clients ) {
+			return;
+		}
+
+		const jsonData = safeStringify( Object.fromEntries( clients ), { indentation: 2 } );
+		const timestamp = Date.now();
+		const filename = `rtc-debug-${ timestamp }.json`;
+
+		downloadBlob( filename, jsonData, 'application/json' );
+	};
+
+	return (
+		<Button
+			variant="secondary"
+			onClick={ handleDownload }
+			style={ { width: '100%', marginTop: '8px' } }
+		>
+			{ __( 'Export Debug Data', 'vip-real-time-collaboration' ) }
+		</Button>
+	);
+}

--- a/src/components/debug-data-export-button.tsx
+++ b/src/components/debug-data-export-button.tsx
@@ -7,12 +7,19 @@ import { AwarenessManager } from '@/awareness-manager';
 
 export function DebugDataExportButton() {
 	const handleDownload = () => {
-		const clients = AwarenessManager.getYDocClients();
-		if ( ! clients ) {
+		const debugData = AwarenessManager.getDebugData();
+
+		if ( ! debugData ) {
 			return;
 		}
 
-		const jsonData = safeStringify( Object.fromEntries( clients ), { indentation: 2 } );
+		const jsonData = safeStringify(
+			{
+				doc: debugData.doc,
+				clients: Object.fromEntries( debugData.clients ),
+			},
+			{ indentation: 2 }
+		);
 		const timestamp = Date.now();
 		const filename = `rtc-debug-${ timestamp }.json`;
 

--- a/src/components/debug-data-export-button.tsx
+++ b/src/components/debug-data-export-button.tsx
@@ -7,11 +7,6 @@ import { AwarenessManager } from '@/awareness-manager';
 
 const handleDebugDataDownload = () => {
 	const debugData = AwarenessManager.getDebugData();
-
-	if ( ! debugData ) {
-		return;
-	}
-
 	const jsonData = safeStringify( debugData, { indentation: 2 } );
 	const timestamp = Date.now();
 	const filename = `rtc-debug-${ timestamp }.json`;

--- a/src/components/debug-data-export-button.tsx
+++ b/src/components/debug-data-export-button.tsx
@@ -13,13 +13,7 @@ export function DebugDataExportButton() {
 			return;
 		}
 
-		const jsonData = safeStringify(
-			{
-				doc: debugData.doc,
-				clients: debugData.clients,
-			},
-			{ indentation: 2 }
-		);
+		const jsonData = safeStringify( debugData, { indentation: 2 } );
 		const timestamp = Date.now();
 		const filename = `rtc-debug-${ timestamp }.json`;
 

--- a/src/components/debug-data-export-button.tsx
+++ b/src/components/debug-data-export-button.tsx
@@ -5,25 +5,25 @@ import safeStringify from 'safe-stringify';
 
 import { AwarenessManager } from '@/awareness-manager';
 
+const handleDebugDataDownload = () => {
+	const debugData = AwarenessManager.getDebugData();
+
+	if ( ! debugData ) {
+		return;
+	}
+
+	const jsonData = safeStringify( debugData, { indentation: 2 } );
+	const timestamp = Date.now();
+	const filename = `rtc-debug-${ timestamp }.json`;
+
+	downloadBlob( filename, jsonData, 'application/json' );
+};
+
 export function DebugDataExportButton() {
-	const handleDownload = () => {
-		const debugData = AwarenessManager.getDebugData();
-
-		if ( ! debugData ) {
-			return;
-		}
-
-		const jsonData = safeStringify( debugData, { indentation: 2 } );
-		const timestamp = Date.now();
-		const filename = `rtc-debug-${ timestamp }.json`;
-
-		downloadBlob( filename, jsonData, 'application/json' );
-	};
-
 	return (
 		<Button
 			variant="secondary"
-			onClick={ handleDownload }
+			onClick={ handleDebugDataDownload }
 			style={ { width: '100%', marginTop: '8px' } }
 		>
 			{ __( 'Export Debug Data', 'vip-real-time-collaboration' ) }

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -144,10 +144,6 @@ export function RTCSettingsPanel() {
 						{ __( 'Notifications', 'vip-real-time-collaboration' ) }
 					</Heading>
 
-					<Heading level={ 2 } style={ { marginBottom: '2px' } }>
-						{ __( 'Post', 'vip-real-time-collaboration' ) }
-					</Heading>
-
 					<ToggleControl
 						label="Save/Publish"
 						checked={ isPostUpdateNotificationEnabled }

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -8,6 +8,7 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 
 import { Avatars } from './avatars';
 import { CollaborationModePicker } from './collaboration-mode-picker';
+import { DebugDataExportButton } from './debug-data-export-button';
 import { DebugTools } from './debug-tools';
 import { PostLockedModal } from './post-locked-modal';
 import { RTCOverlay } from './rtc-overlay';
@@ -170,6 +171,11 @@ export function RTCSettingsPanel() {
 							setSetting( Setting.USER_EXIT_NOTIFICATION, enabled )
 						}
 					/>
+
+					<Heading level={ 3 } style={ { marginTop: '24px' } }>
+						{ __( 'Debug', 'vip-real-time-collaboration' ) }
+					</Heading>
+					<DebugDataExportButton />
 				</div>
 				<div className="vip-telemetry-target"></div>
 			</PluginDocumentSettingPanel>

--- a/src/store/awareness-store.ts
+++ b/src/store/awareness-store.ts
@@ -30,6 +30,9 @@ export interface EditorState {
 }
 
 export interface AwarenessStore {
+	// The set of currently active user client IDs.
+	currentUsers: Set< number >;
+	// For all users seen in this session, a map of client ID to user state.
 	userMap: Map< number, UserState >;
 }
 
@@ -60,6 +63,7 @@ type AwarenessAction =
 	| UpsertUserAction;
 
 const DEFAULT_STATE: AwarenessStore = {
+	currentUsers: new Set< number >(),
 	userMap: new Map< number, UserState >(),
 };
 
@@ -108,10 +112,11 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 				return state;
 			}
 
+			state.currentUsers.add( action.payload.clientId );
 			state.userMap.set( action.payload.clientId, updatedState );
 
 			return {
-				...state,
+				currentUsers: new Set( state.currentUsers ),
 				userMap: new Map( state.userMap ),
 			};
 		}
@@ -123,16 +128,16 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 				sendNotification( NotificationType.UserExited, existingState.userInfo );
 			}
 
-			state.userMap.delete( action.payload.clientId );
+			state.currentUsers.delete( action.payload.clientId );
 
 			return {
 				...state,
-				userMap: new Map( state.userMap ),
+				currentUsers: new Set( state.currentUsers ),
 			};
 		}
 
 		case 'UPDATE_EDITOR_STATE': {
-			if ( ! state.userMap.has( action.payload.clientId ) ) {
+			if ( ! state.currentUsers.has( action.payload.clientId ) ) {
 				return state;
 			}
 
@@ -179,10 +184,11 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 				);
 			}
 
+			state.currentUsers.add( action.payload.clientId );
 			state.userMap.set( action.payload.clientId, action.payload.userState );
 
 			return {
-				...state,
+				currentUsers: new Set( state.currentUsers ),
 				userMap: new Map( state.userMap ),
 			};
 		}
@@ -194,9 +200,16 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 
 const selectors = {
 	getActiveClientIds( state: AwarenessStore ): number[] {
-		return Array.from( state.userMap.keys() );
+		return Array.from( state.currentUsers.values() );
 	},
 	getActiveUsers( state: AwarenessStore ): Map< number, UserState > {
+		return new Map(
+			Array.from( state.userMap.entries() ).filter( ( [ clientId ] ) =>
+				state.currentUsers.has( clientId )
+			)
+		);
+	},
+	getSeenUsers( state: AwarenessStore ): Map< number, UserState > {
 		return state.userMap;
 	},
 	isDisconnected( state: AwarenessStore ): boolean {


### PR DESCRIPTION
> Linear - [VIP-2463](https://linear.app/a8c/issue/VIP-2463)

Adds a new button in the RTC settings panel that exports the following debug data JSON with following structure -

```typescript
interface YDocDebugData {
	doc: {
		state: {
			version: number;
		};
		// YJS representation of Gutenberg entity
		document: {
			[key: string]: unknown;
		};
	};
	clients: {
		[clientId: string]: {
			id: {
				client: number;
				clock: number;
			};
			length: number;
			origin: string | null;
			rightOrigin: string | null;
			// YJS parent object
			parent: Record<string, unknown>;
			// key in the parent object for the current item
			parentSub: string;
			redone: Record<string, unknown> | null;
			content: Record<string, unknown>;
			info: number;
			// YJS left item reference
			left: Record<string, unknown> | null;
			// YJS right item reference
			right: Record<string, unknown> | null;
		}[];
	};
	// Map of the YJS client ID to the WordPress user as YJS client ID is re-generated on each refresh
	userMap: {
		[clientId: string]: {
			wpUserId: number;
			name: string;
			email: string;
		};
	};
}
```

This would be useful in understanding how the Post blocks/attributes are updated in a collaborative session by participants.

### Screenshots

<img width="1449" height="859" alt="Screenshot 2025-11-25 at 10 38 29 PM" src="https://github.com/user-attachments/assets/4ea5be33-53a3-4286-9040-bed1fd3148fc" />
