### PR TITLE
Add websocket server tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: Automattic/vip-actions/nodejs-setup@trunk
         with:
-          node-version-file: .nvmrc
+          node-version-file: ./websocket-server/nvmrc
           ignore-scripts: true
           working-directory: ./websocket-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: Automattic/vip-actions/nodejs-setup@trunk
         with:
-          node-version-file: ./websocket-server/nvmrc
+          node-version-file: ./websocket-server/.nvmrc
           ignore-scripts: true
           working-directory: ./websocket-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,18 @@ jobs:
 
       - name: Run JS unit tests
         run: npm run test:js:unit
+
+  test-wss:
+    name: js-unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: Automattic/vip-actions/nodejs-setup@trunk
+        with:
+          node-version-file: .nvmrc
+          ignore-scripts: true
+          working-directory: ./websocket-server
+
+      - name: Run JS unit tests
+        run: npm run test
+        working-directory: ./websocket-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: Automattic/vip-actions/nodejs-setup@trunk
         with:
-          node-version-file: .nvmrc
+          node-version: websocket-server/.nvmrc
           ignore-scripts: true
           working-directory: websocket-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: Automattic/vip-actions/nodejs-setup@trunk
         with:
-          node-version: websocket-server/.nvmrc
+          node-version: ./websocket-server/.nvmrc
           ignore-scripts: true
           working-directory: websocket-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           # Node.js version here instead of pointing to the .nvmrc file.
           node-version: 22
           ignore-scripts: true
-          working-directory: ./websocket-server
+          working-directory: websocket-server
 
       - name: Run JS unit tests
         run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Setup Node.js
         uses: Automattic/vip-actions/nodejs-setup@trunk
         with:
-          node-version-file: ./websocket-server/.nvmrc
+          # A bug in the working-directory handling requires us to hardcode the
+          # Node.js version here instead of pointing to the .nvmrc file.
+          node-version: 22
           ignore-scripts: true
           working-directory: ./websocket-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: Automattic/vip-actions/nodejs-setup@trunk
         with:
-          node-version: ./websocket-server/.nvmrc
+          node-version-file: websocket-server/.nvmrc
           ignore-scripts: true
           working-directory: websocket-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: Automattic/vip-actions/nodejs-setup@trunk
         with:
-          # A bug in the working-directory handling requires us to hardcode the
-          # Node.js version here instead of pointing to the .nvmrc file.
-          node-version: 22
+          node-version-file: .nvmrc
           ignore-scripts: true
           working-directory: websocket-server
 

--- a/bin/start
+++ b/bin/start
@@ -4,6 +4,7 @@ set -e # Exit immediately if any command exits with a non-zero status.
 
 # Set WordPress port and home URL.
 PORT="${WP_ENV_PORT-8888}"
+METRICS_PORT="${METRICS_PORT-9090}"
 WP_HOME="${WP_ENV_HOME_URL-http://localhost:$PORT}"
 WS_PORT="${WS_PORT-1234}"
 YJS_INSPECTOR_PORT="${YJS_INSPECTOR_PORT-5173}"
@@ -91,7 +92,7 @@ install_dependencies() {
 
 start_websocket_server() {
     echo "🔼 Starting WebSocket server development build..."
-    VIP_RTC_WS_AUTH_SECRET=vip_rtc_ws_auth_secret PORT=$WS_PORT npm run -s dev:websocket-server &
+    VIP_RTC_WS_AUTH_SECRET=vip_rtc_ws_auth_secret METRICS_PORT=$METRICS_PORT PORT=$WS_PORT npm run -s dev:websocket-server &
 }
 
 start_yjs_inspector() {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts",
     "test:e2e:debug": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts --ui",
     "test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/vip-real-time-collaboration ./vendor/bin/phpunit -c phpunit-integration.xml",
-    "test:js:unit": "npx tsx --experimental-test-module-mocks --test src/**/*.test.ts websocket-server/**/*.test.ts",
+    "test:js:unit": "npx tsx --experimental-test-module-mocks --test src/**/*.test.ts",
     "wp-cli": "wp-env run cli -- wp"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts",
     "test:e2e:debug": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts --ui",
     "test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/vip-real-time-collaboration ./vendor/bin/phpunit -c phpunit-integration.xml",
-    "test:js:unit": "npx tsx --experimental-test-module-mocks --test src/**/*.test.ts",
+    "test:js:unit": "npx tsx --experimental-test-module-mocks --test src/**/*.test.ts websocket-server/**/*.test.ts",
     "wp-cli": "wp-env run cli -- wp"
   },
   "devDependencies": {

--- a/src/utilities/local-storage.ts
+++ b/src/utilities/local-storage.ts
@@ -10,7 +10,7 @@ const logger = new Logger( 'local-storage' );
  */
 export const loadFromLocalStorage = < T >( key: string, defaultValue: T ): T => {
 	try {
-		const saved = localStorage.getItem( key );
+		const saved = global.window?.localStorage?.getItem( key );
 		if ( saved ) {
 			const parsed = JSON.parse( saved ) as T;
 			// If the parsed value is an object (and not null or array), merge with defaultValue

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,5 @@
     "typeRoots": [ "./types", "./node_modules/@types" ],
     "sourceMap": true
   },
-  "include": [ "./types/*.d.ts", "./src/**/*", "./tests/**/*" ],
-  "exclude": [ "./websocket-server/**/*" ]
+  "include": [ "./types/*.d.ts", "./src/**/*", "./tests/**/*", "./websocket-server/**/*" ]
 }

--- a/websocket-server/.dockerignore
+++ b/websocket-server/.dockerignore
@@ -1,3 +1,4 @@
 /dist
 /node_modules
 Dockerfile
+*.test.ts

--- a/websocket-server/auth.test.ts
+++ b/websocket-server/auth.test.ts
@@ -1,0 +1,165 @@
+import jwt from 'jsonwebtoken';
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, Mock, mock } from 'node:test';
+
+import { getConnectionId, isRequestAuthenticated, type SyncTokenPayload } from './auth';
+
+import type { IncomingMessage } from 'node:http';
+
+const MOCK_JWT_SECRET = 'mock-jwt-secret';
+const EXPIRED_TIMESTAMP = Math.floor( Date.now() / 1000 ) - 3600; // 1 hour ago
+
+function createRequest( url?: string ): IncomingMessage {
+	return { url } as IncomingMessage;
+}
+
+function createValidToken( payload: Partial< SyncTokenPayload > = {} ): string {
+	return jwt.sign(
+		{
+			connection_id: 'conn-123',
+			room_name: 'test-room',
+			user_id: 42,
+			username: 'testuser',
+			...payload,
+		},
+		MOCK_JWT_SECRET
+	);
+}
+
+describe( 'getConnectionId', () => {
+	it( 'should return connection_id from valid token', () => {
+		const token = createValidToken( { connection_id: 'conn-456' } );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		assert.strictEqual( getConnectionId( request, MOCK_JWT_SECRET ), 'conn-456' );
+	} );
+
+	it( 'should return null when token is missing', () => {
+		const request = createRequest( '/test-room' );
+		assert.strictEqual( getConnectionId( request, MOCK_JWT_SECRET ), null );
+	} );
+
+	it( 'should return null for invalid token', () => {
+		const request = createRequest( '/test-room?auth=invalid-token' );
+		assert.strictEqual( getConnectionId( request, MOCK_JWT_SECRET ), null );
+	} );
+
+	it( 'should return null for token with wrong secret', () => {
+		const token = createValidToken( {} );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		assert.strictEqual( getConnectionId( request, 'wrong-secret' ), null );
+	} );
+
+	it( 'should return null for expired token', () => {
+		const token = createValidToken( {
+			exp: EXPIRED_TIMESTAMP,
+		} );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		assert.strictEqual( getConnectionId( request, MOCK_JWT_SECRET ), null );
+	} );
+
+	it( 'should handle request with no URL', () => {
+		const request = createRequest();
+		assert.strictEqual( getConnectionId( request, MOCK_JWT_SECRET ), null );
+	} );
+} );
+
+describe( 'isRequestAuthenticated', () => {
+	let mockConsoleError: Mock< typeof console.error >;
+
+	beforeEach( () => {
+		mockConsoleError = mock.method( console, 'error', () => {} );
+	} );
+
+	afterEach( () => {
+		mock.restoreAll();
+	} );
+
+	it( 'should return authenticated true for valid token and matching room', () => {
+		const token = createValidToken();
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, true );
+	} );
+
+	it( 'should return authenticated true with _ws/ prefix in URL', () => {
+		const token = createValidToken();
+		const request = createRequest( `/_ws/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, true );
+	} );
+
+	it( 'should return missing_token when auth param is absent', () => {
+		const request = createRequest( '/test-room' );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'missing_token' );
+	} );
+
+	it( 'should return invalid_token for malformed token', () => {
+		const request = createRequest( '/test-room?auth=invalid-token' );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_token' );
+	} );
+
+	it( 'should return invalid_token for token with wrong secret', () => {
+		const token = createValidToken();
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, 'wrong-secret' );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_token' );
+	} );
+
+	it( 'should return invalid_payload when room names do not match', () => {
+		const token = createValidToken( { room_name: 'other-room' } );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_payload' );
+		assert.strictEqual( result.reason, 'invalid_payload' );
+		assert.strictEqual( mockConsoleError.mock.calls.length, 1 );
+	} );
+
+	it( 'should return invalid_token for expired token', () => {
+		const token = createValidToken( {
+			exp: EXPIRED_TIMESTAMP,
+		} );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_token' );
+	} );
+
+	it( 'should return invalid_token for token missing required fields', () => {
+		const token = createValidToken( {
+			room_name: undefined,
+			user_id: undefined,
+			username: undefined,
+		} );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_token' );
+	} );
+
+	it( 'should handle URLs with trailing slashes', () => {
+		const token = createValidToken();
+		const request = createRequest( `/test-room/?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, true );
+	} );
+
+	it( 'should handle complex room names with slashes', () => {
+		const token = createValidToken( { room_name: 'site/123/post/456' } );
+		const request = createRequest( `/site/123/post/456?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, true );
+	} );
+
+	it( 'should handle complex room names with _ws/ prefix', () => {
+		const token = createValidToken( { room_name: 'site/123/post/456' } );
+		const request = createRequest( `/_ws/site/123/post/456?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, true );
+	} );
+} );

--- a/websocket-server/auth.ts
+++ b/websocket-server/auth.ts
@@ -1,0 +1,106 @@
+import jwt, { type JwtPayload } from 'jsonwebtoken';
+
+import { getRequestPathname } from './utils';
+
+import type { IncomingMessage } from 'node:http';
+
+interface AuthSuccessResult {
+	authenticated: true;
+}
+
+interface AuthFailureResult {
+	authenticated: false;
+	reason: 'missing_token' | 'invalid_token' | 'invalid_payload';
+}
+
+export interface SyncTokenPayload extends JwtPayload {
+	connection_id: string;
+	room_name: string;
+	user_id: number;
+	username: string;
+}
+
+function isSyncTokenPayload( payload: unknown ): payload is SyncTokenPayload {
+	return (
+		typeof payload === 'object' &&
+		payload !== null &&
+		'user_id' in payload &&
+		'username' in payload &&
+		'room_name' in payload &&
+		'connection_id' in payload
+	);
+}
+
+function verifyToken( token: string | null | undefined, secret: string ): SyncTokenPayload {
+	if ( ! token ) {
+		throw new Error( 'Missing token' );
+	}
+
+	const jwtPayload = jwt.verify( token, secret );
+	if ( ! isSyncTokenPayload( jwtPayload ) ) {
+		throw new Error( 'Invalid JWT payload' );
+	}
+
+	return jwtPayload;
+}
+
+/**
+ * Verify that the room_name in the JWT payload matches with the request URL
+ * to guard against a token being used for the different sync object that it was issued for.
+ *
+ * TODO: Add additonal check for user_id
+ */
+function validateTokenPayload( request: IncomingMessage, jwtPayload: SyncTokenPayload ): boolean {
+	// Extract room name from token and URL, stripping leading slash and _ws/ prefix from URL path
+	const { room_name: roomNameFromToken } = jwtPayload;
+	const pathname = getRequestPathname( request );
+	const roomNameFromUrl = pathname.replace( /^\/(_ws\/)?/, '' );
+
+	const isValid = roomNameFromToken === roomNameFromUrl;
+	if ( ! isValid ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`JWT decoded successfully but token payload is invalid: ${ JSON.stringify( {
+				roomNameFromToken,
+				roomNameFromUrl,
+			} ) }`
+		);
+		return false;
+	}
+	return true;
+}
+
+export function getConnectionId( request: IncomingMessage, secret: string ): string | null {
+	const searchParams = new URLSearchParams( request.url?.split( '?' )[ 1 ] || '' );
+	const authToken = searchParams.get( 'auth' );
+
+	try {
+		const jwtPayload = verifyToken( authToken, secret );
+		return jwtPayload.connection_id;
+	} catch {
+		return null;
+	}
+}
+
+export function isRequestAuthenticated(
+	request: IncomingMessage,
+	secret: string
+): AuthFailureResult | AuthSuccessResult {
+	const searchParams = new URLSearchParams( request.url?.split( '?' )[ 1 ] || '' );
+	const authToken = searchParams.get( 'auth' );
+
+	if ( ! authToken ) {
+		return { authenticated: false, reason: 'missing_token' };
+	}
+
+	try {
+		const jwtPayload = verifyToken( authToken, secret );
+		const isValid = validateTokenPayload( request, jwtPayload );
+		if ( ! isValid ) {
+			return { authenticated: false, reason: 'invalid_payload' };
+		}
+		return { authenticated: true };
+	} catch ( error ) {
+		return { authenticated: false, reason: 'invalid_token' };
+	}
+}

--- a/websocket-server/config.ts
+++ b/websocket-server/config.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_CONNECTION_TIMEOUT = 4 * 60 * 60 * 1000; // 4 hours in ms
+export const DEFAULT_PORT = 1234;
+export const DEFAULT_HOST = 'localhost';
+
+export const JWT_SECRET = process.env.VIP_RTC_WS_AUTH_SECRET ?? '';
+
+export const WEBSOCKET_CLOSE_CODES: Map< number, string > = new Map( [
+	[ 4001, 'Connection timed out. Reconnect.' ],
+] );
+
+if ( ! JWT_SECRET ) {
+	// eslint-disable-next-line no-console
+	console.error( 'VIP_RTC_WS_AUTH_SECRET environment variable is not set' );
+	process.exit( 1 );
+}

--- a/websocket-server/index.ts
+++ b/websocket-server/index.ts
@@ -1,67 +1,27 @@
 import { setPersistence, setupWSConnection } from '@y/websocket-server/utils';
-import http from 'http';
-import jwt from 'jsonwebtoken';
-import { WebSocketServer } from 'ws';
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import { RawData, WebSocketServer, type WebSocket } from 'ws';
 
+import { getConnectionId, isRequestAuthenticated } from './auth';
+import {
+	DEFAULT_CONNECTION_TIMEOUT,
+	DEFAULT_HOST,
+	DEFAULT_PORT,
+	JWT_SECRET,
+	WEBSOCKET_CLOSE_CODES,
+} from './config';
 import {
 	recordMessage,
 	recordAuthFailure,
 	recordConnectionClose,
 	createMetricsServer,
 	startMetricsMaintenanceLoop,
-	getRequestPathname,
 	recordConnectionOpen,
 } from './metrics';
 import { NoopPersistenceProvider } from './noop-persistence-provider';
+import { getRequestPathname } from './utils';
 
-const jwtSecret = process.env.VIP_RTC_WS_AUTH_SECRET;
-if ( ! jwtSecret ) {
-	// eslint-disable-next-line no-console
-	console.error( 'VIP_RTC_WS_AUTH_SECRET environment variable is not set' );
-	process.exit( 1 );
-}
-
-/**
- * ------------------------------------------------------------
- * Types
- * ------------------------------------------------------------
- */
-interface AuthSuccessResult {
-	authenticated: true;
-}
-
-interface AuthFailureResult {
-	authenticated: false;
-	reason: 'missing_token' | 'invalid_token' | 'invalid_payload';
-}
-
-type AuthResult = AuthSuccessResult | AuthFailureResult;
-
-interface SyncTokenPayload extends jwt.JwtPayload {
-	user_id: number;
-	username: string;
-	room_name: string;
-	connection_id: string;
-}
-
-/**
- * ------------------------------------------------------------
- * Constants
- * ------------------------------------------------------------
- */
-const WEBSOCKET_CLOSE_CODES = new Map< number, string >( [
-	[ 4001, 'Connection timed out. Reconnect.' ],
-] );
-
-/**
- * ------------------------------------------------------------
- * Default values
- * ------------------------------------------------------------
- */
-const DEFAULT_CONNECTION_TIMEOUT = 4 * 60 * 60 * 1000; // 4 hours in ms
-const DEFAULT_PORT = 1234;
-const DEFAULT_HOST = 'localhost';
-const DEFAULT_METRICS_PORT = 9090;
+import type { Duplex } from 'node:stream';
 
 /**
  * ------------------------------------------------------------
@@ -71,106 +31,15 @@ const DEFAULT_METRICS_PORT = 9090;
 const wss = new WebSocketServer( { noServer: true } );
 const host = process.env.HOST || DEFAULT_HOST;
 const port = parseInt( process.env.PORT || '', 10 ) || DEFAULT_PORT;
-const metricsPort = parseInt( process.env.METRICS_PORT || '', 10 ) || DEFAULT_METRICS_PORT;
 const connectionTimeout =
 	parseInt( process.env.CONNECTION_TIMEOUT || '', 10 ) || DEFAULT_CONNECTION_TIMEOUT;
-
-/**
- * ------------------------------------------------------------
- * Helper functions
- * ------------------------------------------------------------
- */
-
-function isSyncTokenPayload( payload: unknown ): payload is SyncTokenPayload {
-	return (
-		typeof payload === 'object' &&
-		payload !== null &&
-		'user_id' in payload &&
-		'username' in payload &&
-		'room_name' in payload &&
-		'connection_id' in payload
-	);
-}
-
-function verifyToken( token: string ): SyncTokenPayload {
-	if ( ! jwtSecret ) {
-		// Just to appease the type checker. Won't happen due to null check above.
-		throw new Error( 'JWT secret not configured' );
-	}
-	const jwtPayload = jwt.verify( token, jwtSecret );
-	if ( ! isSyncTokenPayload( jwtPayload ) ) {
-		throw new Error( 'Invalid JWT payload' );
-	}
-	return jwtPayload;
-}
-
-function getConnectionId( request: http.IncomingMessage ): string | null {
-	const searchParams = new URLSearchParams( request.url?.split( '?' )[ 1 ] || '' );
-	const authToken = searchParams.get( 'auth' );
-	if ( ! authToken ) {
-		return null;
-	}
-
-	try {
-		const jwtPayload = verifyToken( authToken );
-		return jwtPayload.connection_id;
-	} catch {
-		return null;
-	}
-}
-
-/**
- * Verify that the room_name in the JWT payload matches with the request URL
- * to guard against a token being used for the different sync object that it was issued for.
- *
- * TODO: Add additonal check for user_id
- */
-function validateTokenPayload( request: http.IncomingMessage, jwtPayload: SyncTokenPayload ) {
-	// Extract room name from token and URL, stripping leading slash and _ws/ prefix from URL path
-	const { room_name: roomNameFromToken } = jwtPayload;
-	const pathname = getRequestPathname( request );
-	const roomNameFromUrl = pathname.replace( /^\/(_ws\/)?/, '' );
-
-	const isValid = roomNameFromToken === roomNameFromUrl;
-	if ( ! isValid ) {
-		// eslint-disable-next-line no-console
-		console.error(
-			`JWT decoded successfully but token payload is invalid: ${ JSON.stringify( {
-				roomNameFromToken,
-				roomNameFromUrl,
-			} ) }`
-		);
-		return false;
-	}
-	return true;
-}
-
-function isRequestAuthenticated( request: http.IncomingMessage ): AuthResult {
-	const searchParams = new URLSearchParams( request.url?.split( '?' )[ 1 ] || '' );
-	const authToken = searchParams.get( 'auth' );
-
-	if ( ! authToken ) {
-		return { authenticated: false, reason: 'missing_token' };
-	}
-
-	try {
-		const jwtPayload = verifyToken( authToken );
-		const isValid = validateTokenPayload( request, jwtPayload );
-		if ( ! isValid ) {
-			return { authenticated: false, reason: 'invalid_payload' };
-		}
-		return { authenticated: true };
-	} catch ( error ) {
-		return { authenticated: false, reason: 'invalid_token' };
-	}
-}
 
 /**
  * ------------------------------------------------------------
  * Server Configuration
  * ------------------------------------------------------------
  */
-const server = http.createServer( ( request, response ) => {
+const server = http.createServer( ( request: IncomingMessage, response: ServerResponse ): void => {
 	const pathname = getRequestPathname( request );
 
 	if ( [ '/cache-healthcheck', '/health', '/ready' ].includes( pathname ) ) {
@@ -189,8 +58,6 @@ const server = http.createServer( ( request, response ) => {
 	response.end( 'Not Found' );
 } );
 
-const metricsServer = createMetricsServer();
-
 // Use NoopPersistenceProvider to avoid persisting document updates to storage
 // while still allowing documents to be evicted from memory when there are
 // no active connections.
@@ -201,9 +68,9 @@ setPersistence( new NoopPersistenceProvider() );
  * WebSocket connection handling
  * ------------------------------------------------------------
  */
-wss.on( 'connection', ( ws, request ) => {
+wss.on( 'connection', ( ws: WebSocket, request: IncomingMessage ) => {
 	const connectionStartTime = Date.now();
-	const connectionId = getConnectionId( request );
+	const connectionId = getConnectionId( request, JWT_SECRET );
 
 	/**
 	 * Set up the connection
@@ -215,7 +82,7 @@ wss.on( 'connection', ( ws, request ) => {
 	/**
 	 * Track message metrics
 	 */
-	ws.on( 'message', ( data, isBinary ) => {
+	ws.on( 'message', ( data: RawData, isBinary: boolean ): void => {
 		recordMessage( data, isBinary );
 	} );
 
@@ -223,7 +90,7 @@ wss.on( 'connection', ( ws, request ) => {
 	 * Disconnect after some time to force a reconnect
 	 * with new auth token
 	 */
-	const timeout = setTimeout( () => {
+	const timeout = setTimeout( (): void => {
 		// 4001 - custom close code for connection timeout
 		ws.close( 4001, WEBSOCKET_CLOSE_CODES.get( 4001 ) );
 	}, connectionTimeout );
@@ -231,17 +98,17 @@ wss.on( 'connection', ( ws, request ) => {
 	/**
 	 * Clear timeout and update metrics when connection closes
 	 */
-	ws.on( 'close', code => {
+	ws.on( 'close', ( code: number ): void => {
 		clearTimeout( timeout );
 		recordConnectionClose( code, connectionStartTime, connectionId );
 	} );
 } );
 
-server.on( 'upgrade', ( request, socket, head ) => {
+server.on( 'upgrade', ( request: IncomingMessage, socket: Duplex, head: Buffer ): void => {
 	/**
 	 * Verify authentication before establishing WebSocket connection
 	 */
-	const authResult = isRequestAuthenticated( request );
+	const authResult = isRequestAuthenticated( request, JWT_SECRET );
 	if ( authResult.authenticated === false ) {
 		recordAuthFailure( authResult.reason );
 		socket.write( 'HTTP/1.1 401 Unauthorized\r\n\r\n' );
@@ -249,7 +116,7 @@ server.on( 'upgrade', ( request, socket, head ) => {
 		return;
 	}
 
-	wss.handleUpgrade( request, socket, head, ws => {
+	wss.handleUpgrade( request, socket, head, ( ws: WebSocket ): void => {
 		wss.emit( 'connection', ws, request );
 	} );
 } );
@@ -259,14 +126,20 @@ server.on( 'upgrade', ( request, socket, head ) => {
  * Server start
  * ------------------------------------------------------------
  */
-server.listen( port, host, () => {
+server.listen( port, host, (): void => {
 	// eslint-disable-next-line no-console
 	console.log( `WebSocket server running at ws://${ host }:${ port }` );
 } );
 
-metricsServer.listen( metricsPort, host, () => {
-	// eslint-disable-next-line no-console
-	console.log( `WebSocket metrics server running at http://${ host }:${ metricsPort }` );
+// Start the metrics server only if METRICS_PORT is set.
+if ( process.env.METRICS_PORT ) {
+	const metricsPort = parseInt( process.env.METRICS_PORT, 10 );
+	const metricsServer = createMetricsServer();
 
-	startMetricsMaintenanceLoop( wss );
-} );
+	metricsServer.listen( metricsPort, host, (): void => {
+		// eslint-disable-next-line no-console
+		console.log( `WebSocket metrics server running at http://${ host }:${ metricsPort }` );
+
+		startMetricsMaintenanceLoop( wss );
+	} );
+}

--- a/websocket-server/metrics.ts
+++ b/websocket-server/metrics.ts
@@ -1,6 +1,8 @@
 import http from 'http';
 import { register, Counter, Gauge, Histogram } from 'prom-client';
 
+import { getRawDataSizeBytes, getRequestPathname } from './utils';
+
 import type { RawData, WebSocketServer } from 'ws';
 
 /**
@@ -70,37 +72,6 @@ const reconnectionTimeHistogram = new Histogram( {
 	help: 'Time between WebSocket disconnection and reconnection in seconds',
 	buckets: [ 0.1, 0.5, 1, 2, 5, 10, 15, 30, 60 ], // 100ms to 60s
 } );
-
-/**
- * ------------------------------------------------------------
- * Helper functions
- * ------------------------------------------------------------
- */
-export function getRequestPathname( request: http.IncomingMessage ): string {
-	const pathname = request.url?.split( '?' )[ 0 ] || '/';
-	// Remove trailing slashes (except for root path)
-	return pathname === '/' ? pathname : pathname.replace( /\/+$/, '' );
-}
-
-function getRawDataSizeBytes( data: RawData ): number {
-	if ( Array.isArray( data ) ) {
-		let total = 0;
-		for ( const bufferChunk of data ) {
-			total += bufferChunk.length;
-		}
-		return total;
-	}
-
-	if ( Buffer.isBuffer( data ) ) {
-		return data.length;
-	}
-
-	if ( data instanceof ArrayBuffer ) {
-		return data.byteLength;
-	}
-
-	return 0;
-}
 
 /**
  * ------------------------------------------------------------

--- a/websocket-server/package-lock.json
+++ b/websocket-server/package-lock.json
@@ -17,26 +17,8 @@
         "@types/jsonwebtoken": "9.0.10",
         "@types/node": "22.19.0",
         "@types/ws": "8.5.0",
-        "tsx": "4.20.5",
         "typescript": "5.9.2",
         "yjs": "13.6.27"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
-      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -260,76 +242,6 @@
       },
       "bin": {
         "errno": "cli.js"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
-      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.10",
-        "@esbuild/android-arm": "0.25.10",
-        "@esbuild/android-arm64": "0.25.10",
-        "@esbuild/android-x64": "0.25.10",
-        "@esbuild/darwin-arm64": "0.25.10",
-        "@esbuild/darwin-x64": "0.25.10",
-        "@esbuild/freebsd-arm64": "0.25.10",
-        "@esbuild/freebsd-x64": "0.25.10",
-        "@esbuild/linux-arm": "0.25.10",
-        "@esbuild/linux-arm64": "0.25.10",
-        "@esbuild/linux-ia32": "0.25.10",
-        "@esbuild/linux-loong64": "0.25.10",
-        "@esbuild/linux-mips64el": "0.25.10",
-        "@esbuild/linux-ppc64": "0.25.10",
-        "@esbuild/linux-riscv64": "0.25.10",
-        "@esbuild/linux-s390x": "0.25.10",
-        "@esbuild/linux-x64": "0.25.10",
-        "@esbuild/netbsd-arm64": "0.25.10",
-        "@esbuild/netbsd-x64": "0.25.10",
-        "@esbuild/openbsd-arm64": "0.25.10",
-        "@esbuild/openbsd-x64": "0.25.10",
-        "@esbuild/openharmony-arm64": "0.25.10",
-        "@esbuild/sunos-x64": "0.25.10",
-        "@esbuild/win32-arm64": "0.25.10",
-        "@esbuild/win32-ia32": "0.25.10",
-        "@esbuild/win32-x64": "0.25.10"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/ieee754": {
@@ -700,16 +612,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -759,26 +661,6 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
-      }
-    },
-    "node_modules/tsx": {
-      "version": "4.20.5",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
-      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/websocket-server/package.json
+++ b/websocket-server/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "tsx watch index.ts",
+    "dev": "npx tsx watch index.ts",
     "start": "node dist/index.js",
     "test": "npx tsx --experimental-test-module-mocks --test *.test.ts"
   },
@@ -20,7 +20,6 @@
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "22.19.0",
     "@types/ws": "8.5.0",
-    "tsx": "4.20.5",
     "typescript": "5.9.2",
     "yjs": "13.6.27"
   }

--- a/websocket-server/package.json
+++ b/websocket-server/package.json
@@ -6,8 +6,9 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "dev": "tsx watch index.ts",
     "start": "node dist/index.js",
-    "dev": "tsx watch index.ts"
+    "test": "npx tsx --experimental-test-module-mocks --test *.test.ts"
   },
   "dependencies": {
     "@y/websocket-server": "0.1.1",

--- a/websocket-server/utils.test.ts
+++ b/websocket-server/utils.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { getRequestPathname, getRawDataSizeBytes } from './utils';
+
+import type { IncomingMessage } from 'node:http';
+
+function createRequest( url?: string ): IncomingMessage {
+	return { url } as IncomingMessage;
+}
+
+describe( 'getRequestPathname', () => {
+	it( 'should return "/" for root path', () => {
+		const request = createRequest( '/' );
+		assert.strictEqual( getRequestPathname( request ), '/' );
+	} );
+
+	it( 'should extract pathname from URL without query string', () => {
+		const request = createRequest( '/api/users' );
+		assert.strictEqual( getRequestPathname( request ), '/api/users' );
+	} );
+
+	it( 'should remove query parameters', () => {
+		const request = createRequest( '/api/users?id=123&name=test' );
+		assert.strictEqual( getRequestPathname( request ), '/api/users' );
+	} );
+
+	it( 'should remove trailing slashes from non-root paths', () => {
+		const request = createRequest( '/api/users/' );
+		assert.strictEqual( getRequestPathname( request ), '/api/users' );
+	} );
+
+	it( 'should remove multiple trailing slashes', () => {
+		const request = createRequest( '/api/users///' );
+		assert.strictEqual( getRequestPathname( request ), '/api/users' );
+	} );
+
+	it( 'should remove trailing slashes and query parameters', () => {
+		const request = createRequest( '/api/users/?id=123' );
+		assert.strictEqual( getRequestPathname( request ), '/api/users' );
+	} );
+
+	it( 'should preserve root path with trailing slash', () => {
+		const request = createRequest( '/?' );
+		assert.strictEqual( getRequestPathname( request ), '/' );
+	} );
+
+	it( 'should handle missing URL', () => {
+		const request = createRequest();
+		assert.strictEqual( getRequestPathname( request ), '/' );
+	} );
+
+	it( 'should handle undefined URL', () => {
+		const request = createRequest( undefined );
+		assert.strictEqual( getRequestPathname( request ), '/' );
+	} );
+
+	it( 'should handle empty string URL', () => {
+		const request = createRequest( '' );
+		assert.strictEqual( getRequestPathname( request ), '/' );
+	} );
+} );
+
+describe( 'getRawDataSizeBytes', () => {
+	it( 'should calculate size of a single Buffer', () => {
+		const buffer = Buffer.from( 'hello world' );
+		assert.strictEqual( getRawDataSizeBytes( buffer ), 11 );
+	} );
+
+	it( 'should calculate size of an empty Buffer', () => {
+		const buffer = Buffer.from( '' );
+		assert.strictEqual( getRawDataSizeBytes( buffer ), 0 );
+	} );
+
+	it( 'should calculate size of an array of Buffers', () => {
+		const buffers = [ Buffer.from( 'hello' ), Buffer.from( ' ' ), Buffer.from( 'world' ) ];
+		assert.strictEqual( getRawDataSizeBytes( buffers ), 11 );
+	} );
+
+	it( 'should calculate size of an empty array', () => {
+		const buffers: Buffer[] = [];
+		assert.strictEqual( getRawDataSizeBytes( buffers ), 0 );
+	} );
+
+	it( 'should calculate size of an array with one Buffer', () => {
+		const buffers = [ Buffer.from( 'test' ) ];
+		assert.strictEqual( getRawDataSizeBytes( buffers ), 4 );
+	} );
+
+	it( 'should calculate size of an ArrayBuffer', () => {
+		const arrayBuffer = new ArrayBuffer( 20 );
+		assert.strictEqual( getRawDataSizeBytes( arrayBuffer ), 20 );
+	} );
+
+	it( 'should calculate size of an empty ArrayBuffer', () => {
+		const arrayBuffer = new ArrayBuffer( 0 );
+		assert.strictEqual( getRawDataSizeBytes( arrayBuffer ), 0 );
+	} );
+
+	it( 'should handle ArrayBuffer with UTF-8 data', () => {
+		const encoder = new TextEncoder();
+		const arrayBuffer = encoder.encode( 'hello world' ).buffer;
+		assert.strictEqual( getRawDataSizeBytes( arrayBuffer ), 11 );
+	} );
+
+	it( 'should calculate size with multi-byte characters', () => {
+		const buffer = Buffer.from( 'Hello 世界' );
+		assert.strictEqual( getRawDataSizeBytes( buffer ), 12 );
+	} );
+
+	it( 'should handle array of Buffers with varying sizes', () => {
+		const buffers = [
+			Buffer.from( 'a' ),
+			Buffer.from( 'bb' ),
+			Buffer.from( 'ccc' ),
+			Buffer.from( 'dddd' ),
+		];
+		assert.strictEqual( getRawDataSizeBytes( buffers ), 10 );
+	} );
+} );

--- a/websocket-server/utils.ts
+++ b/websocket-server/utils.ts
@@ -1,0 +1,28 @@
+import type { IncomingMessage } from 'node:http';
+import type { RawData } from 'ws';
+
+export function getRawDataSizeBytes( data: RawData ): number {
+	if ( Array.isArray( data ) ) {
+		let total = 0;
+		for ( const bufferChunk of data ) {
+			total += bufferChunk.length;
+		}
+		return total;
+	}
+
+	if ( Buffer.isBuffer( data ) ) {
+		return data.length;
+	}
+
+	if ( data instanceof ArrayBuffer ) {
+		return data.byteLength;
+	}
+
+	return 0;
+}
+
+export function getRequestPathname( request: IncomingMessage ): string {
+	const pathname = request.url?.split( '?' )[ 0 ] || '/';
+	// Remove trailing slashes (except for root path)
+	return pathname === '/' ? pathname : pathname.replace( /\/+$/, '' );
+}


### PR DESCRIPTION
- Add unit tests for WebSocket server functions, which requires some refactoring.
- Conditionally start metrics server based on presence of `METRICS_PORT` env var.
- Improve types.
- Run type checker against websocket server code.
- Fix warning when accessing `localStorage` in non-browser environments.