### PR TITLE
Specify algorithm in WebSocket JWT verification

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,25 @@ module.exports = {
 	},
 	overrides: [
 		{
+			files: [ 'websocket-server/**/*.ts' ],
+			excludedFiles: [ 'websocket-server/utils.ts', 'websocket-server/**/*.test.ts' ],
+			rules: {
+				'no-restricted-imports': [
+					'error',
+					{
+						paths: [
+							{
+								name: 'jsonwebtoken',
+								importNames: [ 'default', 'verify' ],
+								message:
+									'Use verifyJwtToken from websocket-server/utils instead to ensure algorithm is always specified to prevent algorithm confusion attacks. Named imports other than verify are allowed.',
+							},
+						],
+					},
+				],
+			},
+		},
+		{
 			files: [ '*.test.ts' ], // Node.js unit tests
 			rules: {
 				'@typescript-eslint/no-floating-promises': 'off',

--- a/websocket-server/auth.test.ts
+++ b/websocket-server/auth.test.ts
@@ -116,7 +116,6 @@ describe( 'isRequestAuthenticated', () => {
 		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
 		assert.strictEqual( result.authenticated, false );
 		assert.strictEqual( result.reason, 'invalid_payload' );
-		assert.strictEqual( result.reason, 'invalid_payload' );
 		assert.strictEqual( mockConsoleError.mock.calls.length, 1 );
 	} );
 

--- a/websocket-server/auth.test.ts
+++ b/websocket-server/auth.test.ts
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import jwt, { type SignOptions } from 'jsonwebtoken';
 import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it, Mock, mock } from 'node:test';
 
@@ -13,7 +13,10 @@ function createRequest( url?: string ): IncomingMessage {
 	return { url } as IncomingMessage;
 }
 
-function createValidToken( payload: Partial< SyncTokenPayload > = {} ): string {
+function createValidToken(
+	payload: Partial< SyncTokenPayload > = {},
+	options: SignOptions = {}
+): string {
 	return jwt.sign(
 		{
 			connection_id: 'conn-123',
@@ -22,7 +25,8 @@ function createValidToken( payload: Partial< SyncTokenPayload > = {} ): string {
 			username: 'testuser',
 			...payload,
 		},
-		MOCK_JWT_SECRET
+		MOCK_JWT_SECRET,
+		options
 	);
 }
 
@@ -160,5 +164,22 @@ describe( 'isRequestAuthenticated', () => {
 		const request = createRequest( `/_ws/site/123/post/456?auth=${ token }` );
 		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
 		assert.strictEqual( result.authenticated, true );
+	} );
+
+	it( 'should reject token signed with wrong algorithm', () => {
+		// Create a token using HS512 instead of HS256
+		const token = createValidToken( {}, { algorithm: 'HS512' } );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_token' );
+	} );
+
+	it( 'should reject token with "none" algorithm', () => {
+		const token = createValidToken( {}, { algorithm: 'none' } );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_token' );
 	} );
 } );

--- a/websocket-server/auth.ts
+++ b/websocket-server/auth.ts
@@ -36,7 +36,7 @@ function verifyToken( token: string | null | undefined, secret: string ): SyncTo
 		throw new Error( 'Missing token' );
 	}
 
-	const jwtPayload = jwt.verify( token, secret );
+	const jwtPayload = jwt.verify( token, secret, { algorithms: [ 'HS256' ] } );
 	if ( ! isSyncTokenPayload( jwtPayload ) ) {
 		throw new Error( 'Invalid JWT payload' );
 	}

--- a/websocket-server/auth.ts
+++ b/websocket-server/auth.ts
@@ -1,6 +1,6 @@
-import jwt, { type JwtPayload } from 'jsonwebtoken';
+import { type JwtPayload } from 'jsonwebtoken';
 
-import { getRequestPathname } from './utils';
+import { getRequestPathname, verifyJwtToken } from './utils';
 
 import type { IncomingMessage } from 'node:http';
 
@@ -36,7 +36,7 @@ function verifyToken( token: string | null | undefined, secret: string ): SyncTo
 		throw new Error( 'Missing token' );
 	}
 
-	const jwtPayload = jwt.verify( token, secret, { algorithms: [ 'HS256' ] } );
+	const jwtPayload = verifyJwtToken( token, secret, { algorithms: [ 'HS256' ] } );
 	if ( ! isSyncTokenPayload( jwtPayload ) ) {
 		throw new Error( 'Invalid JWT payload' );
 	}

--- a/websocket-server/utils.ts
+++ b/websocket-server/utils.ts
@@ -1,5 +1,11 @@
+import jwt, { type Jwt, type JwtPayload, type VerifyOptions } from 'jsonwebtoken';
+
 import type { IncomingMessage } from 'node:http';
 import type { RawData } from 'ws';
+
+type WithRequired< T, K extends keyof T > = Omit< T, K > & Required< Pick< T, K > >;
+
+type VerifyOptionsWithAlgorithms = WithRequired< VerifyOptions, 'algorithms' >;
 
 export function getRawDataSizeBytes( data: RawData ): number {
 	if ( Array.isArray( data ) ) {
@@ -25,4 +31,24 @@ export function getRequestPathname( request: IncomingMessage ): string {
 	const pathname = request.url?.split( '?' )[ 0 ] || '/';
 	// Remove trailing slashes (except for root path)
 	return pathname === '/' ? pathname : pathname.replace( /\/+$/, '' );
+}
+
+/**
+ * Safely verify a JWT token with required algorithm specification.
+ *
+ * This wrapper enforces that the 'algorithms' parameter is always provided,
+ * preventing algorithm confusion attacks where an attacker could manipulate
+ * the algorithm in the JWT header to bypass signature verification.
+ *
+ * @param token - The JWT token to verify
+ * @param secret - The secret key used to verify the token
+ * @param options - Verification options with REQUIRED algorithms field
+ * @returns The decoded JWT payload
+ */
+export function verifyJwtToken(
+	token: string,
+	secret: string,
+	options: VerifyOptionsWithAlgorithms
+): JwtPayload | Jwt | string {
+	return jwt.verify( token, secret, options );
 }


### PR DESCRIPTION
## Summary

Improves WebSocket JWT authentication security by explicitly specifying the allowed algorithm during token verification.

## Why

Without explicitly specifying the algorithm, the JWT library accepts whatever algorithm is declared in the token header. This allows attackers to manipulate the algorithm field to bypass signature verification.

By explicitly requiring HS256, we ensure only tokens signed with our expected algorithm are accepted.