### PR TITLE
Add connection limit to WebSocket server

### DIFF
--- a/websocket-server/auth.test.ts
+++ b/websocket-server/auth.test.ts
@@ -114,12 +114,12 @@ describe( 'isRequestAuthenticated', () => {
 		assert.strictEqual( result.reason, 'invalid_token' );
 	} );
 
-	it( 'should return invalid_payload when room names do not match', () => {
+	it( 'should return invalid_token_payload when room names do not match', () => {
 		const token = createValidToken( { room_name: 'other-room' } );
 		const request = createRequest( `/test-room?auth=${ token }` );
 		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
 		assert.strictEqual( result.authenticated, false );
-		assert.strictEqual( result.reason, 'invalid_payload' );
+		assert.strictEqual( result.reason, 'invalid_token_payload' );
 		assert.strictEqual( mockConsoleError.mock.calls.length, 1 );
 	} );
 

--- a/websocket-server/auth.ts
+++ b/websocket-server/auth.ts
@@ -10,7 +10,7 @@ interface AuthSuccessResult {
 
 interface AuthFailureResult {
 	authenticated: false;
-	reason: 'missing_token' | 'invalid_token' | 'invalid_payload';
+	reason: 'missing_token' | 'invalid_token' | 'invalid_token_payload';
 }
 
 export interface SyncTokenPayload extends JwtPayload {
@@ -97,7 +97,7 @@ export function isRequestAuthenticated(
 		const jwtPayload = verifyToken( authToken, secret );
 		const isValid = validateTokenPayload( request, jwtPayload );
 		if ( ! isValid ) {
-			return { authenticated: false, reason: 'invalid_payload' };
+			return { authenticated: false, reason: 'invalid_token_payload' };
 		}
 		return { authenticated: true };
 	} catch ( error ) {

--- a/websocket-server/config.ts
+++ b/websocket-server/config.ts
@@ -1,8 +1,11 @@
 export const DEFAULT_CONNECTION_TIMEOUT = 4 * 60 * 60 * 1000; // 4 hours in ms
 export const DEFAULT_PORT = 1234;
 export const DEFAULT_HOST = 'localhost';
+export const DEFAULT_MAX_CONNECTIONS = 1500;
 
 export const JWT_SECRET = process.env.VIP_RTC_WS_AUTH_SECRET ?? '';
+export const MAX_CONNECTIONS =
+	parseInt( process.env.VIP_RTC_WS_MAX_CONNECTIONS || '', 10 ) || DEFAULT_MAX_CONNECTIONS;
 
 export const WEBSOCKET_CLOSE_CODES: Map< number, string > = new Map( [
 	[ 4001, 'Connection timed out. Reconnect.' ],

--- a/websocket-server/config.ts
+++ b/websocket-server/config.ts
@@ -9,6 +9,7 @@ export const MAX_CONNECTIONS =
 
 export const WEBSOCKET_CLOSE_CODES: Map< number, string > = new Map( [
 	[ 4001, 'Connection timed out. Reconnect.' ],
+	[ 4002, 'Server connection limit reached. Please try again later.' ],
 ] );
 
 if ( ! JWT_SECRET ) {

--- a/websocket-server/index.ts
+++ b/websocket-server/index.ts
@@ -13,9 +13,8 @@ import {
 } from './config';
 import {
 	recordMessage,
-	recordAuthFailure,
 	recordConnectionClose,
-	recordConnectionLimitReached,
+	recordConnectionFailure,
 	createMetricsServer,
 	startMetricsMaintenanceLoop,
 	recordConnectionOpen,
@@ -112,33 +111,23 @@ server.on( 'upgrade', ( request: IncomingMessage, socket: Duplex, head: Buffer )
 	 */
 	const authResult = isRequestAuthenticated( request, JWT_SECRET );
 	if ( authResult.authenticated === false ) {
-		recordAuthFailure( authResult.reason );
+		recordConnectionFailure( authResult.reason );
 		socket.write( 'HTTP/1.1 401 Unauthorized\r\n\r\n' );
 		socket.destroy();
 		return;
 	}
 
-	/**
-	 * Check connection limit (if configured)
-	 * The value of MAX_CONNECTIONS=-1 means no limit
-	 */
-	if ( MAX_CONNECTIONS !== -1 && wss.clients.size >= MAX_CONNECTIONS ) {
-		recordConnectionLimitReached();
-		const errorResponse = JSON.stringify( {
-			code: 'connection_limit_reached',
-			message: 'WebSocket server connection limit reached. Please try again later.',
-		} );
-		socket.write(
-			'HTTP/1.1 503 Service Unavailable\r\n' +
-				'Content-Type: application/json\r\n' +
-				'\r\n' +
-				errorResponse
-		);
-		socket.destroy();
-		return;
-	}
-
 	wss.handleUpgrade( request, socket, head, ( ws: WebSocket ): void => {
+		/**
+		 * Check connection limit (if configured)
+		 * The value of MAX_CONNECTIONS=-1 means no limit
+		 */
+		if ( MAX_CONNECTIONS !== -1 && wss.clients.size > MAX_CONNECTIONS ) {
+			recordConnectionFailure( 'connection_limit_exceeded' );
+			ws.close( 4002, WEBSOCKET_CLOSE_CODES.get( 4002 ) );
+			return;
+		}
+
 		wss.emit( 'connection', ws, request );
 	} );
 } );

--- a/websocket-server/index.ts
+++ b/websocket-server/index.ts
@@ -8,12 +8,14 @@ import {
 	DEFAULT_HOST,
 	DEFAULT_PORT,
 	JWT_SECRET,
+	MAX_CONNECTIONS,
 	WEBSOCKET_CLOSE_CODES,
 } from './config';
 import {
 	recordMessage,
 	recordAuthFailure,
 	recordConnectionClose,
+	recordConnectionLimitReached,
 	createMetricsServer,
 	startMetricsMaintenanceLoop,
 	recordConnectionOpen,
@@ -112,6 +114,26 @@ server.on( 'upgrade', ( request: IncomingMessage, socket: Duplex, head: Buffer )
 	if ( authResult.authenticated === false ) {
 		recordAuthFailure( authResult.reason );
 		socket.write( 'HTTP/1.1 401 Unauthorized\r\n\r\n' );
+		socket.destroy();
+		return;
+	}
+
+	/**
+	 * Check connection limit (if configured)
+	 * The value of MAX_CONNECTIONS=-1 means no limit
+	 */
+	if ( MAX_CONNECTIONS !== -1 && wss.clients.size >= MAX_CONNECTIONS ) {
+		recordConnectionLimitReached();
+		const errorResponse = JSON.stringify( {
+			code: 'connection_limit_reached',
+			message: 'WebSocket server connection limit reached. Please try again later.',
+		} );
+		socket.write(
+			'HTTP/1.1 503 Service Unavailable\r\n' +
+				'Content-Type: application/json\r\n' +
+				'\r\n' +
+				errorResponse
+		);
 		socket.destroy();
 		return;
 	}

--- a/websocket-server/metrics.ts
+++ b/websocket-server/metrics.ts
@@ -61,6 +61,11 @@ const connectionCloseCounter = new Counter( {
 	labelNames: [ 'code' ],
 } );
 
+const connectionLimitReachedCounter = new Counter( {
+	name: `${ METRICS_NAMESPACE }_connection_limit_reached_total`,
+	help: 'Total number of connections rejected due to connection limit',
+} );
+
 const connectionDurationHistogram = new Histogram( {
 	name: `${ METRICS_NAMESPACE }_connection_duration_seconds`,
 	help: 'Duration of WebSocket connections in seconds',
@@ -92,6 +97,10 @@ export function recordMessage( data: RawData, isBinary: boolean ): void {
 
 export function recordAuthFailure( reason: string ): void {
 	authFailuresCounter.inc( { reason } );
+}
+
+export function recordConnectionLimitReached(): void {
+	connectionLimitReachedCounter.inc();
 }
 
 export function recordConnectionOpen( connectionId: string | null ): void {

--- a/websocket-server/metrics.ts
+++ b/websocket-server/metrics.ts
@@ -49,21 +49,16 @@ const messageBytesCounter = new Counter( {
 	help: 'Total bytes of WebSocket messages',
 } );
 
-const authFailuresCounter = new Counter( {
-	name: `${ METRICS_NAMESPACE }_auth_failures_total`,
-	help: 'Total number of WebSocket authentication failures',
-	labelNames: [ 'reason' ],
-} );
-
 const connectionCloseCounter = new Counter( {
 	name: `${ METRICS_NAMESPACE }_connections_closed_total`,
 	help: 'Total number of WebSocket connections closed',
 	labelNames: [ 'code' ],
 } );
 
-const connectionLimitReachedCounter = new Counter( {
-	name: `${ METRICS_NAMESPACE }_connection_limit_reached_total`,
-	help: 'Total number of connections rejected due to connection limit',
+const connectionFailuresCounter = new Counter( {
+	name: `${ METRICS_NAMESPACE }_connection_failures_total`,
+	help: 'Total number of WebSocket connection failures',
+	labelNames: [ 'reason' ],
 } );
 
 const connectionDurationHistogram = new Histogram( {
@@ -95,12 +90,8 @@ export function recordMessage( data: RawData, isBinary: boolean ): void {
 	}
 }
 
-export function recordAuthFailure( reason: string ): void {
-	authFailuresCounter.inc( { reason } );
-}
-
-export function recordConnectionLimitReached(): void {
-	connectionLimitReachedCounter.inc();
+export function recordConnectionFailure( reason: string ): void {
+	connectionFailuresCounter.inc( { reason } );
 }
 
 export function recordConnectionOpen( connectionId: string | null ): void {


### PR DESCRIPTION
# Add connection limit to WebSocket server

## Summary

Adds configurable connection limits to the WebSocket server to prevent overload and maintain stability. When the limit is reached, new connections are rejected with a clear error message.

## Changes

- **Connection limit enforcement**: Rejects connections when `MAX_CONNECTIONS` is reached
- **Configurable via environment**: Set `VIP_RTC_WS_MAX_CONNECTIONS` (default: 1500, or -1 for unlimited)
- **Structured error responses**: Returns HTTP 503 with JSON body containing error code and message
- **Metrics tracking**: New Prometheus counter `wpvip_rtc_connection_limit_reached_total`

## Testing

Test with websocat and curl to verify:
- Connections are properly rejected when limit is reached
- Error response includes correct status code (503) and JSON body
- Error code and message are user-friendly and actionable

### Websocat

```sh
websocat "ws://localhost:1234/site-1/postType/post-{postId}?auth={JWT_TOKEN}"
```

### Curl

Useful to inspect the HTTP response body message.

```sh
curl -s -i \
	-H "Connection: Upgrade" \
	-H "Upgrade: websocket" \
	-H "Sec-WebSocket-Version: 13" \
	-H "Sec-WebSocket-Key: {WEBSOCKET_KEY}" \
	"http://localhost:1234/site-1/postType/post-{postId}?auth={JWT_TOKEN}"
```