### PR TITLE
Add the plugin version information to the plugin settings

### DIFF
--- a/inc/Settings/Settings.php
+++ b/inc/Settings/Settings.php
@@ -62,7 +62,7 @@ final class Settings {
 		add_settings_section(
 			'plugin-settings',
 			'',
-			[ __CLASS__, 'display_settings_instructions' ],
+			'__return_null',
 			self::SETTINGS_PAGE_SLUG
 		);
 
@@ -101,7 +101,9 @@ final class Settings {
 	public static function settings_page_content(): void {
 		?>
 		<div id="vip-real-time-collaboration-settings-wrapper" class="wrap">
-			<h1><?php esc_html_e( 'VIP Real-Time Collaboration Settings', 'vip-real-time-collaboration' ); ?></h1>
+			<h1><?php esc_html_e( 'VIP Real-Time Collaboration', 'vip-real-time-collaboration' ); ?></h1>
+
+			<h2><?php esc_html_e( 'Plugin Settings', 'vip-real-time-collaboration' ); ?></h2>
 			<form action="options.php" method="post">
 				<?php
 				settings_fields( self::SETTINGS_PAGE_SLUG );
@@ -109,6 +111,11 @@ final class Settings {
 				submit_button();
 				?>
 			</form>
+
+			<h2><?php esc_html_e( 'Plugin Debug Information', 'vip-real-time-collaboration' ); ?></h2>
+			<p><?php echo esc_html( 'Plugin Version: ' . ( defined( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION' ) ? VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION : 'Unknown' ) ); ?></p>
+			<p><?php echo esc_html( 'Gutenberg Version: ' . self::get_gutenberg_version() ); ?></p>
+			<p><?php echo esc_html( 'Gutenberg Commit Hash: ' . self::get_gutenberg_commit_hash() ); ?></p>
 		</div>
 		<?php
 	}
@@ -153,12 +160,32 @@ final class Settings {
 		<?php
 	}
 
-	/**
-	 * Display settings instructions.
-	 */
-	public static function display_settings_instructions(): void {
-		?>
-		<p><?php esc_html_e( 'Configure the settings for the VIP Real-Time Collaboration plugin below.', 'vip-real-time-collaboration' ); ?></p>
-		<?php
+	public static function get_gutenberg_version(): string {
+		// For dev builds, this is defined in the Gutenberg plugin's main file.
+		// For production builds, this is removed entirely.
+		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && constant( 'GUTENBERG_DEVELOPMENT_MODE' ) ) {
+			return 'Development';
+		}
+
+		// If its not development mode, and the version is set, get the version.
+		if ( defined( 'GUTENBERG_VERSION' ) && is_string( constant( 'GUTENBERG_VERSION' ) ) ) {
+			/** @var string $gutenberg_version */
+			$gutenberg_version = constant( 'GUTENBERG_VERSION' );
+
+			return $gutenberg_version;
+		}
+
+		return 'Unknown';
+	}
+
+	public static function get_gutenberg_commit_hash(): string {
+		if ( defined( 'GUTENBERG_GIT_COMMIT' ) && is_string( constant( 'GUTENBERG_GIT_COMMIT' ) ) ) {
+			/** @var string $gutenberg_commit_hash */
+			$gutenberg_commit_hash = constant( 'GUTENBERG_GIT_COMMIT' );
+
+			return $gutenberg_commit_hash;
+		}
+
+		return 'Unknown';
 	}
 }

--- a/inc/Settings/Settings.php
+++ b/inc/Settings/Settings.php
@@ -112,7 +112,7 @@ final class Settings {
 				?>
 			</form>
 
-			<h2><?php esc_html_e( 'Plugin Debug Information', 'vip-real-time-collaboration' ); ?></h2>
+			<h2><?php esc_html_e( 'Debug Information', 'vip-real-time-collaboration' ); ?></h2>
 			<p>
 				<?php
 				/* translators: %s: Plugin version */

--- a/inc/Settings/Settings.php
+++ b/inc/Settings/Settings.php
@@ -14,10 +14,10 @@ final class Settings {
 	}
 
 	public static function is_vip_rtc_enabled(): bool {
-		/** @var array<string> */
+		/** @var array<string, mixed> */
 		$options = get_option( self::OPTION_NAME, self::get_default_options() );
 
-		return isset( $options['enable-vip-rtc'] ) && (bool) $options['enable-vip-rtc'];
+		return ! empty( $options['enable-vip-rtc'] );
 	}
 
 	/**
@@ -113,9 +113,24 @@ final class Settings {
 			</form>
 
 			<h2><?php esc_html_e( 'Plugin Debug Information', 'vip-real-time-collaboration' ); ?></h2>
-			<p><?php echo esc_html( 'Plugin Version: ' . ( defined( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION' ) ? VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION : 'Unknown' ) ); ?></p>
-			<p><?php echo esc_html( 'Gutenberg Version: ' . self::get_gutenberg_version() ); ?></p>
-			<p><?php echo esc_html( 'Gutenberg Commit Hash: ' . self::get_gutenberg_commit_hash() ); ?></p>
+			<p>
+				<?php
+				/* translators: %s: Plugin version */
+				echo esc_html( sprintf( __( 'Plugin Version: %s', 'vip-real-time-collaboration' ), self::get_vip_rtc_version() ) );
+				?>
+			</p>
+			<p>
+				<?php
+				/* translators: %s: Gutenberg version */
+				echo esc_html( sprintf( __( 'Gutenberg Version: %s', 'vip-real-time-collaboration' ), self::get_gutenberg_version() ) );
+				?>
+			</p>
+			<p>
+				<?php
+				/* translators: %s: Gutenberg commit hash */
+				echo esc_html( sprintf( __( 'Gutenberg Commit Hash: %s', 'vip-real-time-collaboration' ), self::get_gutenberg_commit_hash() ) );
+				?>
+			</p>
 		</div>
 		<?php
 	}
@@ -126,9 +141,9 @@ final class Settings {
 	 * @param array{field_id: string, enabled_label: string, disabled_label: string, description: string} $args Field configuration.
 	 */
 	public static function display_settings_radio( array $args ): void {
-		/** @var array<string> */
+		/** @var array<string, mixed> */
 		$options = get_option( self::OPTION_NAME, self::get_default_options() );
-		$value = isset( $options[ $args['field_id'] ] ) && $options[ $args['field_id'] ];
+		$value = ! empty( $options[ $args['field_id'] ] );
 		$field_name = self::OPTION_NAME . '[' . $args['field_id'] . ']';
 		?>
 		<fieldset>
@@ -160,32 +175,37 @@ final class Settings {
 		<?php
 	}
 
+	/**
+	 * Get a string constant value safely.
+	 *
+	 * @param string $constant_name The constant name to check.
+	 * @return string The constant value or 'Unknown' if not defined or not a string.
+	 */
+	private static function get_string_constant( string $constant_name ): string {
+		if ( ! defined( $constant_name ) || ! is_string( constant( $constant_name ) ) ) {
+			return 'Unknown';
+		}
+
+		/** @var string $value */
+		$value = constant( $constant_name );
+
+		return $value;
+	}
+
+	public static function get_vip_rtc_version(): string {
+		return self::get_string_constant( 'VIP_REAL_TIME_COLLABORATION__PLUGIN_VERSION' );
+	}
+
 	public static function get_gutenberg_version(): string {
 		// For dev builds, this is defined in the Gutenberg plugin's main file.
-		// For production builds, this is removed entirely.
 		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && constant( 'GUTENBERG_DEVELOPMENT_MODE' ) ) {
 			return 'Development';
 		}
 
-		// If its not development mode, and the version is set, get the version.
-		if ( defined( 'GUTENBERG_VERSION' ) && is_string( constant( 'GUTENBERG_VERSION' ) ) ) {
-			/** @var string $gutenberg_version */
-			$gutenberg_version = constant( 'GUTENBERG_VERSION' );
-
-			return $gutenberg_version;
-		}
-
-		return 'Unknown';
+		return self::get_string_constant( 'GUTENBERG_VERSION' );
 	}
 
 	public static function get_gutenberg_commit_hash(): string {
-		if ( defined( 'GUTENBERG_GIT_COMMIT' ) && is_string( constant( 'GUTENBERG_GIT_COMMIT' ) ) ) {
-			/** @var string $gutenberg_commit_hash */
-			$gutenberg_commit_hash = constant( 'GUTENBERG_GIT_COMMIT' );
-
-			return $gutenberg_commit_hash;
-		}
-
-		return 'Unknown';
+		return self::get_string_constant( 'GUTENBERG_GIT_COMMIT' );
 	}
 }


### PR DESCRIPTION
### Description

The problem we face right now is that, it's difficult to tell if the right version of Gutenberg is being used alongside VIP RTC or not. #68 was an attempt at solving this, but that wasn't the right approach given we want all our changes to go into core.

Instead, we are now going to show all the information in the plugin settings page. That way, customers and other users can easily tell what versions of the plugins they are using. We can then use for debugging or reporting issues.

### Development mode

<img width="549" height="441" alt="CleanShot 2025-12-05 at 09 47 46" src="https://github.com/user-attachments/assets/8aba9c02-f281-47a4-8d18-e241d6f307d6" />

### Production mode

<img width="542" height="436" alt="CleanShot 2025-12-05 at 09 49 33" src="https://github.com/user-attachments/assets/40bd37e5-cfef-47a6-86e1-4638d78e476c" />
