### PR TITLE
Switch from using currentUsersIds to currentUsersMap

### DIFF
--- a/src/store/awareness-store.ts
+++ b/src/store/awareness-store.ts
@@ -30,10 +30,10 @@ export interface EditorState {
 }
 
 export interface AwarenessStore {
-	// The set of currently active user client IDs.
-	currentUsers: Set< number >;
 	// For all users seen in this session, a map of client ID to user state.
 	userMap: Map< number, UserState >;
+	// A map of currently active user client IDs to user state.
+	currentUsersMap: Map< number, UserState >;
 }
 
 interface PatchUserInfoAction {
@@ -63,8 +63,8 @@ type AwarenessAction =
 	| UpsertUserAction;
 
 const DEFAULT_STATE: AwarenessStore = {
-	currentUsers: new Set< number >(),
 	userMap: new Map< number, UserState >(),
+	currentUsersMap: new Map< number, UserState >(),
 };
 
 const actions = {
@@ -112,12 +112,12 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 				return state;
 			}
 
-			state.currentUsers.add( action.payload.clientId );
 			state.userMap.set( action.payload.clientId, updatedState );
+			state.currentUsersMap.set( action.payload.clientId, updatedState );
 
 			return {
-				currentUsers: new Set( state.currentUsers ),
 				userMap: new Map( state.userMap ),
+				currentUsersMap: new Map( state.currentUsersMap ),
 			};
 		}
 
@@ -128,16 +128,16 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 				sendNotification( NotificationType.UserExited, existingState.userInfo );
 			}
 
-			state.currentUsers.delete( action.payload.clientId );
+			state.currentUsersMap.delete( action.payload.clientId );
 
 			return {
 				...state,
-				currentUsers: new Set( state.currentUsers ),
+				currentUsersMap: new Map( state.currentUsersMap ),
 			};
 		}
 
 		case 'UPDATE_EDITOR_STATE': {
-			if ( ! state.currentUsers.has( action.payload.clientId ) ) {
+			if ( ! state.currentUsersMap.has( action.payload.clientId ) ) {
 				return state;
 			}
 
@@ -154,10 +154,12 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 			}
 
 			state.userMap.set( action.payload.clientId, updatedState );
+			state.currentUsersMap.set( action.payload.clientId, updatedState );
 
 			return {
 				...state,
 				userMap: new Map( state.userMap ),
+				currentUsersMap: new Map( state.currentUsersMap ),
 			};
 		}
 
@@ -184,12 +186,12 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 				);
 			}
 
-			state.currentUsers.add( action.payload.clientId );
 			state.userMap.set( action.payload.clientId, action.payload.userState );
+			state.currentUsersMap.set( action.payload.clientId, action.payload.userState );
 
 			return {
-				currentUsers: new Set( state.currentUsers ),
 				userMap: new Map( state.userMap ),
+				currentUsersMap: new Map( state.currentUsersMap ),
 			};
 		}
 
@@ -200,14 +202,10 @@ const reducer = ( state = DEFAULT_STATE, action: AwarenessAction ): AwarenessSto
 
 const selectors = {
 	getActiveClientIds( state: AwarenessStore ): number[] {
-		return Array.from( state.currentUsers.values() );
+		return Array.from( state.currentUsersMap.keys() );
 	},
 	getActiveUsers( state: AwarenessStore ): Map< number, UserState > {
-		return new Map(
-			Array.from( state.userMap.entries() ).filter( ( [ clientId ] ) =>
-				state.currentUsers.has( clientId )
-			)
-		);
+		return state.currentUsersMap;
 	},
 	getSeenUsers( state: AwarenessStore ): Map< number, UserState > {
 		return state.userMap;


### PR DESCRIPTION
### Description

In #111, a bug was introduced which causes the following warning:

<img width="636" height="271" alt="CleanShot 2025-12-05 at 12 34 03" src="https://github.com/user-attachments/assets/0309d69a-354b-4ba0-8f63-a29fbdbcf7d5" />

This is because a new map is given back every time the active users are requested.

Instead, this changes that behaviour to build another map of active users and that would in turn power the active client IDs as well as the active users selectors. There'd be no modification happening in the selector, which in turn would mean the warning would stop.

I've verified that there are no changes in the actual way the export feature works so we should be good.

### Testing

1. Load this PR
2. Ensure no warnings are shown
3. Ensure awareness works as expected
4. Ensure exported data has the necessary client IDs