### PR TITLE
[VIP-2558] Remove email for collaborator awareness

### DIFF
--- a/src/awareness/awareness-types.ts
+++ b/src/awareness/awareness-types.ts
@@ -37,7 +37,7 @@ export class TypedAwareness< State extends BaseState > extends Awareness {
 	}
 }
 
-export type WordPressUserInfo = Pick< User, 'id' | 'name' | 'email' > & {
+export type WordPressUserInfo = Pick< User, 'id' | 'name' > & {
 	avatarUrl?: string;
 };
 

--- a/src/awareness/awareness-utils.ts
+++ b/src/awareness/awareness-utils.ts
@@ -10,7 +10,7 @@ import type { AwarenessState } from '@/awareness/awareness-state';
 import type { UserInfo } from '@/awareness/awareness-types';
 
 // WordPress user info for debug export (subset of UserInfo)
-type DebugUserData = Pick< UserInfo, 'name' | 'email' > & {
+type DebugUserData = Pick< UserInfo, 'name' > & {
 	wpUserId: UserInfo[ 'id' ];
 };
 
@@ -53,7 +53,6 @@ export function getDebugData( awareness: AwarenessState ): YDocDebugData {
 		Array.from( awareness.getSeenStates().entries() ).map( ( [ clientId, userState ] ) => [
 			String( clientId ),
 			{
-				email: userState.userInfo.email,
 				name: userState.userInfo.name,
 				wpUserId: userState.userInfo.id,
 			},

--- a/src/components/collaborators-list.scss
+++ b/src/components/collaborators-list.scss
@@ -92,9 +92,5 @@
 			line-height: 16px;
 			font-size: 12px;
 		}
-
-		&-email {
-			color: #757575;
-		}
 	}
 }

--- a/src/components/collaborators-list.tsx
+++ b/src/components/collaborators-list.tsx
@@ -84,9 +84,6 @@ export function CollaboratorsList( {
 								<div className="vip-real-time-collaboration-collaborators-list-item-name">
 									{ userState.userInfo.name }
 								</div>
-								<div className="vip-real-time-collaboration-collaborators-list-item-email">
-									{ userState.userInfo.email }
-								</div>
 							</div>
 						</button>
 					) ) }

--- a/src/utilities/entity.ts
+++ b/src/utilities/entity.ts
@@ -1,16 +1,7 @@
 import { store as coreStore } from '@wordpress/core-data';
-import { select, resolveSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 
 import type { WordPressUserInfo } from '@/awareness/awareness-types';
-import type { User } from '@wordpress/core-data/build-types/entity-types';
-
-async function getUserEmail( userId: number ): Promise< string | undefined > {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-	const user = ( await resolveSelect( coreStore ).getUser( userId, {
-		context: 'edit',
-	} ) ) as User< 'edit' > | undefined;
-	return user?.email;
-}
 
 export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 	const currentUser = select( coreStore ).getCurrentUser() ?? {};
@@ -23,7 +14,6 @@ export async function getCurrentUserInfo(): Promise< WordPressUserInfo > {
 		return await getCurrentUserInfo();
 	}
 	const avatarUrl = avatarUrls?.[ 48 ] || avatarUrls?.[ 96 ] || avatarUrls?.[ 24 ];
-	const email = await getUserEmail( id );
 
-	return { avatarUrl, id, name: name ?? slug, email: email ?? '' };
+	return { avatarUrl, id, name: name ?? slug };
 }

--- a/src/utilities/notifications.test.ts
+++ b/src/utilities/notifications.test.ts
@@ -10,7 +10,6 @@ const baseUserInfo: UserInfo = {
 	name: 'Alice',
 	color: '#000000',
 	browserType: 'chrome',
-	email: 'alice@example.com',
 	enteredAt: Date.now(),
 };
 


### PR DESCRIPTION
A user's email address is not a property available to other users in the "view" context. Therefore, exposing a collaborator's email address in the avatar list contradicts WordPress's access model. In some cases, the request results in an error.