### PR TITLE
Update the collaborate mode's store

### DIFF
--- a/src/components/collaboration-mode-picker.tsx
+++ b/src/components/collaboration-mode-picker.tsx
@@ -56,27 +56,27 @@ export function CollaborationModePicker() {
 	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >( null );
 
 	const { selectedCollaborationEditorMode, shouldPickerBeLockedDown } = useSelect( select => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore ) as EditorStoreSelectors;
-		const { getEditedEntityRecord, getCollaboratorMode } = select( coreStore ) as CoreDataSelectors;
+		const editorSelectors = select( editorStore ) as EditorStoreSelectors;
+		const coreSelectors = select( coreStore ) as CoreDataSelectors;
 
-		const postType = getCurrentPostType();
-		const postId = getCurrentPostId();
+		const postType = editorSelectors.getCurrentPostType();
+		const postId = editorSelectors.getCurrentPostId();
 
 		let isLockedDown = false;
 
 		if ( postType && postId ) {
 			// This mirrors the way it's done in the switchEditorMode action.
-			const entityRecord = getEditedEntityRecord( 'postType', postType, postId ) as
+			const entityRecord = coreSelectors.getEditedEntityRecord( 'postType', postType, postId ) as
 				| EntityRecordWithRtcMeta
 				| undefined;
-			const rtcMeta = entityRecord?.meta?.rtc as RtcMeta | undefined;
+			const rtcMeta = entityRecord?.meta?.rtc;
 			if ( rtcMeta?.enforcedModeOwner && rtcMeta?.enforcedMode === 'codeEditor' ) {
 				isLockedDown = true;
 			}
 		}
 
 		return {
-			selectedCollaborationEditorMode: getCollaboratorMode() as 'edit' | 'view',
+			selectedCollaborationEditorMode: coreSelectors.getCollaboratorMode(),
 			shouldPickerBeLockedDown: isLockedDown,
 		};
 	} );

--- a/src/components/collaboration-mode-picker.tsx
+++ b/src/components/collaboration-mode-picker.tsx
@@ -5,6 +5,7 @@ import {
 	type CoreDataStoreActions,
 } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore, type EditorStoreSelectors } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil, seen, chevronDown } from '@wordpress/icons';
@@ -16,6 +17,19 @@ interface ModeOption {
 	label: string;
 	description: string;
 	icon: JSX.Element;
+}
+
+// RTC meta structure for enforced collaboration mode.
+interface RtcMeta {
+	enforcedMode?: 'codeEditor' | null;
+	enforcedModeOwner?: number | null;
+}
+
+// Entity record with RTC meta.
+interface EntityRecordWithRtcMeta {
+	meta?: {
+		rtc?: RtcMeta;
+	};
 }
 
 const MODES: ModeOption[] = [
@@ -41,9 +55,31 @@ export function CollaborationModePicker() {
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >( null );
 
-	const selectedCollaborationEditorMode = useSelect< CoreDataSelectors, 'edit' | 'view' >( select =>
-		select( coreStore ).getCollaboratorMode()
-	);
+	const { selectedCollaborationEditorMode, shouldPickerBeLockedDown } = useSelect( select => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore ) as EditorStoreSelectors;
+		const { getEditedEntityRecord, getCollaboratorMode } = select( coreStore ) as CoreDataSelectors;
+
+		const postType = getCurrentPostType();
+		const postId = getCurrentPostId();
+
+		let isLockedDown = false;
+
+		if ( postType && postId ) {
+			// This mirrors the way it's done in the switchEditorMode action.
+			const entityRecord = getEditedEntityRecord( 'postType', postType, postId ) as
+				| EntityRecordWithRtcMeta
+				| undefined;
+			const rtcMeta = entityRecord?.meta?.rtc as RtcMeta | undefined;
+			if ( rtcMeta?.enforcedModeOwner && rtcMeta?.enforcedMode === 'codeEditor' ) {
+				isLockedDown = true;
+			}
+		}
+
+		return {
+			selectedCollaborationEditorMode: getCollaboratorMode() as 'edit' | 'view',
+			shouldPickerBeLockedDown: isLockedDown,
+		};
+	} );
 
 	const { setCollaboratorMode } = useDispatch< CoreDataStoreActions >( coreStore );
 
@@ -63,6 +99,7 @@ export function CollaborationModePicker() {
 				isPressed={ isPopoverVisible }
 				size="compact"
 				ref={ setPopoverAnchor }
+				disabled={ shouldPickerBeLockedDown }
 				text={ currentMode?.label }
 				icon={ currentMode?.icon }
 			>

--- a/src/components/collaboration-mode-picker.tsx
+++ b/src/components/collaboration-mode-picker.tsx
@@ -1,10 +1,10 @@
 import { Button, Popover, Icon } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	store as editorStore,
-	type EditorStoreActions,
-	type EditorStoreSelectors,
-} from '@wordpress/editor';
+	store as coreStore,
+	type CoreDataSelectors,
+	type CoreDataStoreActions,
+} from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil, seen, chevronDown } from '@wordpress/icons';
@@ -41,11 +41,11 @@ export function CollaborationModePicker() {
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >( null );
 
-	const selectedCollaborationEditorMode = useSelect< EditorStoreSelectors, 'edit' | 'view' >(
-		select => select( editorStore ).getCollaboratorMode()
+	const selectedCollaborationEditorMode = useSelect< CoreDataSelectors, 'edit' | 'view' >( select =>
+		select( coreStore ).getCollaboratorMode()
 	);
 
-	const { setCollaboratorMode } = useDispatch< EditorStoreActions >( editorStore );
+	const { setCollaboratorMode } = useDispatch< CoreDataStoreActions >( coreStore );
 
 	const currentMode = MODES.find( mode => mode.value === selectedCollaborationEditorMode );
 

--- a/src/hooks/use-disable-block-editing.ts
+++ b/src/hooks/use-disable-block-editing.ts
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { useBlockEditingMode } from '@wordpress/block-editor';
+import { store as coreStore, type CoreDataSelectors } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { store as editorStore, type EditorStoreSelectors } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 
@@ -31,8 +31,8 @@ export function useDisableBlockEditing() {
 	);
 
 	// Get the current collaboration mode (view or edit).
-	const currentCollaborationEditorMode = useSelect< EditorStoreSelectors, 'view' | 'edit' >(
-		select => select( editorStore ).getCollaboratorMode()
+	const currentCollaborationEditorMode = useSelect< CoreDataSelectors, 'view' | 'edit' >( select =>
+		select( coreStore ).getCollaboratorMode()
 	);
 
 	// Determine if view-only mode should be active.

--- a/src/hooks/use-disable-sidebar-interaction.ts
+++ b/src/hooks/use-disable-sidebar-interaction.ts
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { store as coreStore, type CoreDataSelectors } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { store as editorStore, type EditorStoreSelectors } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -19,8 +19,8 @@ import {
  */
 export function useDisableSidebarInteraction() {
 	// Get the current collaboration mode (view or edit).
-	const currentCollaborationEditorMode = useSelect< EditorStoreSelectors, 'view' | 'edit' >(
-		select => select( editorStore ).getCollaboratorMode()
+	const currentCollaborationEditorMode = useSelect< CoreDataSelectors, 'view' | 'edit' >( select =>
+		select( coreStore ).getCollaboratorMode()
 	);
 
 	// Check if the Collaboration Mode Picker setting is enabled.

--- a/types/wordpress__core-data/index.d.ts
+++ b/types/wordpress__core-data/index.d.ts
@@ -1,5 +1,5 @@
 import '@wordpress/core-data';
-import { User } from '@wordpress/core-data';
+import { User, EntityRecord } from '@wordpress/core-data';
 
 declare module '@wordpress/core-data' {
 	const store: {
@@ -9,6 +9,7 @@ declare module '@wordpress/core-data' {
 	interface CoreDataSelectors {
 		getCurrentUser(): User;
 		getCollaboratorMode(): 'view' | 'edit';
+		getEditedEntityRecord( kind: string, name: string, recordId: string | number ): EntityRecord;
 	}
 
 	interface CoreDataStoreActions {

--- a/types/wordpress__core-data/index.d.ts
+++ b/types/wordpress__core-data/index.d.ts
@@ -8,5 +8,10 @@ declare module '@wordpress/core-data' {
 
 	interface CoreDataSelectors {
 		getCurrentUser(): User;
+		getCollaboratorMode(): 'view' | 'edit';
+	}
+
+	interface CoreDataStoreActions {
+		setCollaboratorMode: ( mode: 'view' | 'edit' ) => void;
 	}
 }

--- a/types/wordpress__editor/index.d.ts
+++ b/types/wordpress__editor/index.d.ts
@@ -6,13 +6,7 @@ declare module '@wordpress/editor' {
 		getCurrentPostId(): number | null;
 		getCurrentPostType(): string | null;
 		getEditedPostContent(): string | null;
-		getCollaboratorMode(): 'view' | 'edit';
 	}
-
-	interface EditorStoreActions {
-		setCollaboratorMode: ( mode: 'view' | 'edit' ) => void;
-	}
-
 	export interface EditorPrivateApis {
 		EditorPresence: React.FC< React.PropsWithChildren >;
 		CollaborationMode: React.FC< React.PropsWithChildren >;


### PR DESCRIPTION
### Description

This is a companion PR to [this PR](https://github.com/WordPress/gutenberg/pull/73898). 

It'll move the collaborate mode calls to come from the core-data store instead of the editor store.

An important change: The collaboration mode picker is locked down when the enforced mode is set to prevent anyone from changing the mode they are in.

### Screencast

https://github.com/user-attachments/assets/cc1c464f-827e-4e30-a6ed-77440a173cd4
