### PR TITLE
Improve React linting and simplify render cursor logic

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,8 +52,5 @@ export default defineConfig( [
 				},
 			},
 		},
-		rules: {
-			'no-unused-vars': 'off', // Allow unused vars in example code
-		},
 	},
 ] );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,10 @@
         "y-websocket": "3.0.0"
       },
       "devDependencies": {
-        "@automattic/eslint-plugin-wpvip": "1.1.0",
+        "@automattic/eslint-plugin-wpvip": "1.1.1",
         "@babel/preset-react": "7.28.5",
         "@playwright/test": "^1.57.0",
+        "@types/react": "18.3.27",
         "@types/wordpress__block-editor": "^14.21.0",
         "@wordpress/a11y": "4.34.0",
         "@wordpress/api-fetch": "7.32.0",
@@ -46,6 +47,7 @@
         "husky": "9.1.7",
         "lint-staged": "16.2.0",
         "prettier": "npm:wp-prettier@3.0.3",
+        "react": "18.3.1",
         "safe-stringify": "1.2.0",
         "ts-loader": "9.5.2",
         "typescript": "5.9.2",
@@ -108,9 +110,9 @@
       }
     },
     "node_modules/@automattic/eslint-plugin-wpvip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@automattic/eslint-plugin-wpvip/-/eslint-plugin-wpvip-1.1.0.tgz",
-      "integrity": "sha512-s+Oo5SES5sEW/2J6vEgHCA0M0GCXVUDLeFwIjx/v/bstPxQWkfdJM1Fcb9cMd+JNkN01tfDbS97CzClHZxmcPg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@automattic/eslint-plugin-wpvip/-/eslint-plugin-wpvip-1.1.1.tgz",
+      "integrity": "sha512-Og4+dHcmDa0rYvTEk1QF/mXcMsZbm6vEf2wqLYTnar/jWb7Pq9YUZfaF1n/ppB2QoiefEDfbpyH15cZ0pEpPHg==",
       "dev": true,
       "license": "GPL-2.0+",
       "dependencies": {
@@ -5875,14 +5877,14 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "version": "18.3.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
@@ -15292,9 +15294,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
     "wp-cli": "wp-env run cli -- wp"
   },
   "devDependencies": {
-    "@automattic/eslint-plugin-wpvip": "1.1.0",
+    "@automattic/eslint-plugin-wpvip": "1.1.1",
     "@babel/preset-react": "7.28.5",
     "@playwright/test": "^1.57.0",
+    "@types/react": "18.3.27",
     "@types/wordpress__block-editor": "^14.21.0",
     "@wordpress/a11y": "4.34.0",
     "@wordpress/api-fetch": "7.32.0",
@@ -85,6 +86,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.2.0",
     "prettier": "npm:wp-prettier@3.0.3",
+    "react": "18.3.1",
     "safe-stringify": "1.2.0",
     "ts-loader": "9.5.2",
     "typescript": "5.9.2",

--- a/src/components/collaborators-list.tsx
+++ b/src/components/collaborators-list.tsx
@@ -74,7 +74,7 @@ export function CollaboratorsList( {
 							className="vip-real-time-collaboration-collaborators-list-item"
 							onClick={ () => handleCollaboratorClick( userState.clientId ) }
 							disabled={ ! userState.isConnected }
-							aria-description="Clicking scrolls to cursor position in the editor"
+							aria-label="Clicking scrolls to cursor position in the editor"
 							style={ {
 								opacity: userState.isConnected ? 1 : 0.5,
 							} }

--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
-import { useRef, useState, useEffect } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 
 import { useBlockHighlighting } from '@/hooks/use-block-highlighting';
 import { useRenderCursors } from '@/hooks/use-render-cursors';
@@ -8,49 +8,31 @@ import { type CursorRegistry } from '@/utilities/cursor-registry';
 import '@/components/rtc-overlay.scss';
 
 interface RTCOverlayProps {
-	containerRef: React.MutableRefObject< HTMLElement | null >;
+	blockEditorDocument: Document | null;
 	cursorRegistry: CursorRegistry;
 }
 
 /**
  * This component is responsible for rendering awareness components within the editor iframe.
  */
-export function RTCOverlay( { containerRef, cursorRegistry }: RTCOverlayProps ) {
+export function RTCOverlay( { blockEditorDocument, cursorRegistry }: RTCOverlayProps ) {
 	const overlayRef = useRef< HTMLDivElement >( null );
-	const [ document, setDocument ] = useState< Document | null >( null );
-	const renderCursorsRef = useRenderCursors( overlayRef, document, cursorRegistry );
-
-	useEffect( () => {
-		const ownerDocument = containerRef.current?.ownerDocument ?? null;
-		// Update iframe document on mount, which can happen when switching
-		// between iframed and non-iframed editors in preview mode.
-		setDocument( ownerDocument );
-
-		if ( ownerDocument ) {
-			// Redraw cursors after a short delay to ensure cursors are in the correct position
-			// after frame-changing animations (e.g. Desktop -> Tablet view) have completed.
-			setTimeout( () => {
-				renderCursorsRef.current?.();
-			}, 500 );
-		}
-	}, [ containerRef, renderCursorsRef ] );
+	const rerenderCursorsAfterDelay = useRenderCursors(
+		overlayRef,
+		blockEditorDocument,
+		cursorRegistry
+	);
 
 	// Detect layout changes on overlay (e.g. turning on "Show Template") and window
 	// resizes, and re-render the cursors.
-	const resizeObserverRef = useResizeObserver( () => {
-		renderCursorsRef.current?.();
-	} );
+	const resizeObserverRef = useResizeObserver( rerenderCursorsAfterDelay );
 
 	// Merge the refs to use the same element for both overlay and resize observation
 	const mergedRef = useMergeRefs( [ overlayRef, resizeObserverRef ] );
 
 	useBlockHighlighting( document );
 
-	return (
-		<>
-			{ /* This is a full overlay that covers the entire iframe document.
-				Good for scrollable elements like cursor indicators */ }
-			<div className="vip-real-time-collaboration-overlay-full" ref={ mergedRef } />
-		</>
-	);
+	// This is a full overlay that covers the entire iframe document. Good for
+	// scrollable elements like cursor indicators.
+	return <div className="vip-real-time-collaboration-overlay-full" ref={ mergedRef } />;
 }

--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
-import { useRef } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 import { useBlockHighlighting } from '@/hooks/use-block-highlighting';
 import { useRenderCursors } from '@/hooks/use-render-cursors';
@@ -8,7 +8,7 @@ import { type CursorRegistry } from '@/utilities/cursor-registry';
 import '@/components/rtc-overlay.scss';
 
 interface RTCOverlayProps {
-	blockEditorDocument: Document | null;
+	blockEditorDocument?: Document;
 	cursorRegistry: CursorRegistry;
 }
 
@@ -19,13 +19,14 @@ export function RTCOverlay( { blockEditorDocument, cursorRegistry }: RTCOverlayP
 	const overlayRef = useRef< HTMLDivElement >( null );
 	const rerenderCursorsAfterDelay = useRenderCursors(
 		overlayRef,
-		blockEditorDocument,
+		blockEditorDocument ?? null,
 		cursorRegistry
 	);
 
 	// Detect layout changes on overlay (e.g. turning on "Show Template") and window
 	// resizes, and re-render the cursors.
 	const resizeObserverRef = useResizeObserver( rerenderCursorsAfterDelay );
+	useEffect( rerenderCursorsAfterDelay, [ rerenderCursorsAfterDelay ] );
 
 	// Merge the refs to use the same element for both overlay and resize observation
 	const mergedRef = useMergeRefs( [ overlayRef, resizeObserverRef ] );

--- a/src/components/rtc-overlay.tsx
+++ b/src/components/rtc-overlay.tsx
@@ -18,6 +18,7 @@ interface RTCOverlayProps {
 export function RTCOverlay( { containerRef, cursorRegistry }: RTCOverlayProps ) {
 	const overlayRef = useRef< HTMLDivElement >( null );
 	const [ document, setDocument ] = useState< Document | null >( null );
+	const renderCursorsRef = useRenderCursors( overlayRef, document, cursorRegistry );
 
 	useEffect( () => {
 		const ownerDocument = containerRef.current?.ownerDocument ?? null;
@@ -32,9 +33,7 @@ export function RTCOverlay( { containerRef, cursorRegistry }: RTCOverlayProps ) 
 				renderCursorsRef.current?.();
 			}, 500 );
 		}
-	}, [] );
-
-	const renderCursorsRef = useRenderCursors( overlayRef, document, cursorRegistry );
+	}, [ containerRef, renderCursorsRef ] );
 
 	// Detect layout changes on overlay (e.g. turning on "Show Template") and window
 	// resizes, and re-render the cursors.

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -91,7 +91,10 @@ export function RTCSettingsPanel() {
 			<BlockCanvasCover.Fill>
 				{ ( { containerRef }: { containerRef: React.MutableRefObject< HTMLElement | null > } ) => (
 					<>
-						<RTCOverlay containerRef={ containerRef } cursorRegistry={ cursorRegistry.current } />
+						<RTCOverlay
+							blockEditorDocument={ containerRef.current?.ownerDocument ?? null }
+							cursorRegistry={ cursorRegistry.current }
+						/>
 						{ isDebugToolsEnabled && containerRef.current?.ownerDocument && (
 							<DebugTools iframeDocument={ containerRef.current?.ownerDocument } />
 						) }

--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -92,7 +92,7 @@ export function RTCSettingsPanel() {
 				{ ( { containerRef }: { containerRef: React.MutableRefObject< HTMLElement | null > } ) => (
 					<>
 						<RTCOverlay
-							blockEditorDocument={ containerRef.current?.ownerDocument ?? null }
+							blockEditorDocument={ containerRef.current?.ownerDocument }
 							cursorRegistry={ cursorRegistry.current }
 						/>
 						{ isDebugToolsEnabled && containerRef.current?.ownerDocument && (

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -81,7 +81,7 @@ export function useRenderCursors(
 
 	useEffect( () => {
 		renderCursors();
-	}, [ drawType, sortedUsers, renderCursors ] );
+	}, [ drawType, renderCursors, sortedUsers ] );
 
 	// Return function so that it can be called manually.
 	return () => {

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -73,7 +73,7 @@ export function useRenderCursors(
 
 		// Render cursors immediately when data changes
 		renderCursorsRef.current();
-	}, [ drawType, sortedUsers, overlayRef.current, blockEditorDocument, cursorRegistry ] );
+	}, [ drawType, sortedUsers, overlayRef, blockEditorDocument, cursorRegistry ] );
 
 	return renderCursorsRef;
 }

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -1,5 +1,5 @@
 import { useSelect } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { type RefObject, useEffect, useMemo } from 'react';
 
 import {
 	useActiveUsers,
@@ -10,29 +10,25 @@ import { type CursorRegistry } from '@/utilities/cursor-registry';
 import { Logger } from '@/utilities/logger';
 import { type SelectionCursor, type SelectionState, SelectionType } from '@/utilities/selection';
 
-import type { MutableRefObject } from 'react';
-
 enum DrawType {
 	None,
 	OtherUsers,
 	All,
 }
 
+type RenderCursorsFunction = () => void;
+
 const logger = new Logger( 'use-render-cursors' );
 
 /**
  * Custom hook for rendering cursors for each user in the editor.
- * @param overlayRef - The ref to the overlay element
- * @param blockEditorDocument - The block editor document
- * @returns A ref to the render function. Can be used by parent to trigger a re-render.
+ * @returns A cursor render function. Can be used by parent to redraw cursors as needed.
  */
 export function useRenderCursors(
-	overlayRef: MutableRefObject< HTMLElement | null >,
+	overlayRef: RefObject< HTMLElement | null >,
 	blockEditorDocument: Document | null,
 	cursorRegistry: CursorRegistry
 ) {
-	const renderCursorsRef = useRef< () => void >();
-
 	const drawType = useSelect< SettingsStoreSelectors, DrawType >( select => {
 		const { getSetting } = select( rtcSettingsStore );
 		if ( getSetting( Setting.AWARENESS_CURSORS ) ) {
@@ -49,9 +45,12 @@ export function useRenderCursors(
 	const sortedUsers = useActiveUsers();
 	const getAbsolutePositionIndex = useGetAbsolutePositionIndex();
 
-	// Draw user cursors in the overlay.
-	useEffect( () => {
-		renderCursorsRef.current = () => {
+	const renderCursors = useMemo< RenderCursorsFunction >(
+		() => (): void => {
+			if ( ! overlayRef.current || ! blockEditorDocument ) {
+				return;
+			}
+
 			const userSelections = sortedUsers.map( user => ( {
 				userName: user.userInfo.name,
 				clientId: user.clientId,
@@ -69,13 +68,25 @@ export function useRenderCursors(
 				cursorRegistry,
 				getAbsolutePositionIndex
 			);
-		};
+		},
+		[
+			blockEditorDocument,
+			cursorRegistry,
+			drawType,
+			getAbsolutePositionIndex,
+			overlayRef,
+			sortedUsers,
+		]
+	);
 
-		// Render cursors immediately when data changes
-		renderCursorsRef.current();
-	}, [ drawType, sortedUsers, overlayRef, blockEditorDocument, cursorRegistry ] );
+	useEffect( () => {
+		renderCursors();
+	}, [ drawType, sortedUsers, renderCursors ] );
 
-	return renderCursorsRef;
+	// Return function so that it can be called manually.
+	return () => {
+		setTimeout( renderCursors, 500 );
+	};
 }
 
 /**

--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -79,13 +79,13 @@ export function useRenderCursors(
 		]
 	);
 
-	useEffect( () => {
-		renderCursors();
-	}, [ drawType, renderCursors, sortedUsers ] );
+	useEffect( renderCursors, [ drawType, renderCursors, sortedUsers ] );
 
 	// Return function so that it can be called manually.
 	return () => {
-		setTimeout( renderCursors, 500 );
+		const timeout = setTimeout( renderCursors, 500 );
+
+		return () => clearTimeout( timeout );
 	};
 }
 


### PR DESCRIPTION
React code was not being fully linted because React was not installed as a (dev) dependency. 