### PR TITLE
Fix editor crash when opening Yjs inspector

### DIFF
--- a/src/awareness/awareness-state.ts
+++ b/src/awareness/awareness-state.ts
@@ -253,7 +253,6 @@ export abstract class AwarenessState<
 
 		const updatedStates = new Map< number, EnhancedState< State > >(
 			[ ...this.disconnectedUsers, ...states.keys() ]
-				.filter( clientId => this.seenStates.has( clientId ) )
 				.filter( clientId => {
 					// Exclude any users without `userInfo`.
 					// This can happen from the Yjs inspector, which joins the awareness

--- a/src/awareness/awareness-state.ts
+++ b/src/awareness/awareness-state.ts
@@ -256,10 +256,10 @@ export abstract class AwarenessState<
 				.filter( clientId => this.seenStates.has( clientId ) )
 				.filter( clientId => {
 					const rawState = this.seenStates.get( clientId );
+
 					// Exclude any users without userInfo
 					// This can happen from the Yjs inspector, which joins the awareness
 					// state without providing user data.
-
 					const isUserInfoPresent = rawState?.userInfo !== undefined;
 					return isUserInfoPresent;
 				} )

--- a/src/awareness/awareness-state.ts
+++ b/src/awareness/awareness-state.ts
@@ -255,13 +255,10 @@ export abstract class AwarenessState<
 			[ ...this.disconnectedUsers, ...states.keys() ]
 				.filter( clientId => this.seenStates.has( clientId ) )
 				.filter( clientId => {
-					const rawState = this.seenStates.get( clientId );
-
-					// Exclude any users without userInfo
+					// Exclude any users without `userInfo`.
 					// This can happen from the Yjs inspector, which joins the awareness
 					// state without providing user data.
-					const isUserInfoPresent = rawState?.userInfo !== undefined;
-					return isUserInfoPresent;
+					return Boolean( this.seenStates.get( clientId )?.userInfo );
 				} )
 				.map( clientId => {
 					// The filter above ensures that seenStates has the clientId.

--- a/src/awareness/awareness-state.ts
+++ b/src/awareness/awareness-state.ts
@@ -254,6 +254,15 @@ export abstract class AwarenessState<
 		const updatedStates = new Map< number, EnhancedState< State > >(
 			[ ...this.disconnectedUsers, ...states.keys() ]
 				.filter( clientId => this.seenStates.has( clientId ) )
+				.filter( clientId => {
+					const rawState = this.seenStates.get( clientId );
+					// Exclude any users without userInfo
+					// This can happen from the Yjs inspector, which joins the awareness
+					// state without providing user data.
+
+					const isUserInfoPresent = rawState?.userInfo !== undefined;
+					return isUserInfoPresent;
+				} )
 				.map( clientId => {
 					// The filter above ensures that seenStates has the clientId.
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
## Reproduction

1. Open a post in a local environment with the Yjs inspector enabled.
2. Click the Yjs inspector link and open it in a new tab.
3. Wait a few seconds.
4. See the editor crash:

https://github.com/user-attachments/assets/d3611a98-4ee6-4c63-b01e-676a68a6b89e

```
Uncaught TypeError: can't access property "avatarUrl", userInfo is undefined
    Avatar avatar.tsx:28
```

## Cause

When the Yjs inspector opens, it also connects to the awareness instance on the post entity. Our code currently expects awareness users to provide a minimum set of user data in `userInfo` (like `avatarUrl`) to be used in rendering that the inspector does not provide.

## Fix

Filter out invalid user states without a `userInfo` property.