### PR TITLE
Adding filter for post type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ VIP Real-Time Collaboration (VIP RTC) enables multiple users to edit the same Wo
 
 Out of the box, the plugin works with all WordPress posts and pages, including Custom Post Types.
 
+### Excluding content types from real-time collaboration
+
+If you need to exclude specific content types from real-time collaboration, you can use the `vip_real_time_collaboration_supported_post_types` filter:
+
+```php
+add_filter( 'vip_real_time_collaboration_supported_post_types', function( $post_types ) {
+	// Remove specific post types from collaboration
+	$post_types = array_diff( $post_types, [ 'product', 'custom_post_type' ] );
+	return $post_types;
+} );
+```
+
+**Note:** This filter should be added after the `init` hook has run, as post types are registered at that point. The recommended approach is to add this in a plugin or theme with a priority higher than 10:
+
+```php
+add_action( 'init', function() {
+	add_filter( 'vip_real_time_collaboration_supported_post_types', function( $post_types ) {
+		return array_diff( $post_types, [ 'product' ] );
+	} );
+}, 20 );
+```
+
 ## Requirements
 
 - **WordPress**: 6.7 or newer

--- a/inc/Compatibility/Compatibility.php
+++ b/inc/Compatibility/Compatibility.php
@@ -71,7 +71,14 @@ final class Compatibility {
 	 * @return array<string>
 	 */
 	public static function get_supported_post_types(): array {
-		return get_post_types_by_support( [ 'editor' ] );
+		$post_types = get_post_types_by_support( [ 'editor' ] );
+
+		/**
+		 * Filters the post types that support real-time collaboration.
+		 *
+		 * @param array<string> $post_types Array of post type slugs that support collaborative editing.
+		 */
+		return apply_filters( 'vip_real_time_collaboration_supported_post_types', $post_types );
 	}
 
 	/**

--- a/tests/Integration/CompatibilityTest.php
+++ b/tests/Integration/CompatibilityTest.php
@@ -155,4 +155,75 @@ final class CompatibilityTest extends TestCase {
 
 		$pagenow = $previous_pagenow;
 	}
+
+	/**
+	 * Verifies that get_supported_post_types() returns post types with editor support.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::get_supported_post_types
+	 */
+	public function test_get_supported_post_types_returns_default_post_types(): void {
+		$supported_post_types = Compatibility::get_supported_post_types();
+
+		self::assertIsArray( $supported_post_types, 'Should return an array' );
+		self::assertContains( 'post', $supported_post_types, 'Should include post type' );
+		self::assertContains( 'page', $supported_post_types, 'Should include page type' );
+	}
+
+	/**
+	 * Verifies that the vip_real_time_collaboration_supported_post_types filter works correctly.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::get_supported_post_types
+	 */
+	public function test_get_supported_post_types_filter_can_exclude_post_types(): void {
+		$filter_callback = function ( array $post_types ): array {
+			return array_diff( $post_types, [ 'page' ] );
+		};
+
+		add_filter( 'vip_real_time_collaboration_supported_post_types', $filter_callback );
+
+		$supported_post_types = Compatibility::get_supported_post_types();
+
+		self::assertIsArray( $supported_post_types, 'Should return an array' );
+		self::assertContains( 'post', $supported_post_types, 'Should include post type' );
+		self::assertNotContains( 'page', $supported_post_types, 'Should not include page type after filtering' );
+
+		remove_filter( 'vip_real_time_collaboration_supported_post_types', $filter_callback );
+	}
+
+	/**
+	 * Verifies that the vip_real_time_collaboration_supported_post_types filter works with custom post types.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Compatibility\Compatibility::get_supported_post_types
+	 */
+	public function test_get_supported_post_types_filter_can_exclude_custom_post_types(): void {
+		// Register a custom post type for testing.
+		register_post_type(
+			'product',
+			[
+				'public' => true,
+				'supports' => [ 'editor' ],
+			]
+		);
+
+		// Verify the custom post type is included by default.
+		$supported_post_types = Compatibility::get_supported_post_types();
+		self::assertContains( 'product', $supported_post_types, 'Custom post type should be included by default' );
+
+		// Add filter to exclude the custom post type.
+		$filter_callback = function ( array $post_types ): array {
+			return array_diff( $post_types, [ 'product' ] );
+		};
+
+		add_filter( 'vip_real_time_collaboration_supported_post_types', $filter_callback );
+
+		$supported_post_types = Compatibility::get_supported_post_types();
+
+		self::assertNotContains( 'product', $supported_post_types, 'Custom post type should be excluded after filtering' );
+		self::assertContains( 'post', $supported_post_types, 'Other post types should still be included' );
+
+		remove_filter( 'vip_real_time_collaboration_supported_post_types', $filter_callback );
+
+		// Clean up.
+		unregister_post_type( 'product' );
+	}
 }


### PR DESCRIPTION
This PR adds a filter that lets customers exclude specific post types from real-time collaboration. 

