### PR TITLE
Map the Y from sync correctly

### DIFF
--- a/inc/Assets/Assets.php
+++ b/inc/Assets/Assets.php
@@ -46,10 +46,12 @@ final class Assets {
 		 */
 		$asset = include $asset_file;
 
+		$dependencies = array_unique( array_merge( $asset['dependencies'], [ 'wp-sync' ] ) );
+
 		wp_enqueue_script(
 			'vip-real-time-collaboration',
 			$script_file,
-			$asset['dependencies'],
+			$dependencies,
 			$asset['version'],
 			[ 'in_footer' => false ]
 		);


### PR DESCRIPTION
### Description

As part of the shift to Gutenberg's trunk branch, instead of our custom branch it was noticed that `wp.sync.Y` wasn't being found. This was because `sync` wasn't a dependency when our plugin's scripts were loaded. As a result, our webpack mapping kept failing. This'll resolve that bug.

Credit to @chriszarate who helped me find this bug while working on porting Awareness to Gutenberg's trunk branch.