### PR TITLE
Update createWebSocketConnection function signature

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -239,12 +239,26 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 
 			// Provide some debugging functions in development mode.
 			if ( isDevelopment() ) {
+				// Because there are multiple providers, disconnectWebSocket() and
+				// reconnectWebSocket() will be overridden by the last entity or collection
+				// provider created. Call the previous function if present.
+
+				const previousDisconnectFunction = window.VIP_RTC.debug.disconnectWebSocket;
 				window.VIP_RTC.debug.disconnectWebSocket = () => {
+					if ( previousDisconnectFunction ) {
+						previousDisconnectFunction();
+					}
+
 					provider.off( 'connection-close', connect );
 					provider.disconnect();
 				};
 
+				const previousReconnectFunction = window.VIP_RTC.debug.reconnectWebSocket;
 				window.VIP_RTC.debug.reconnectWebSocket = () => {
+					if ( previousReconnectFunction ) {
+						previousReconnectFunction();
+					}
+
 					provider.on( 'connection-close', connect );
 					void connect();
 				};

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -17,16 +17,24 @@ import { getErrorMessage } from '@/utilities/error';
 import { memoizeFn } from '@/utilities/function';
 import { Logger } from '@/utilities/logger';
 
-import type { ObjectID, ObjectType, ProviderCreator } from '@wordpress/sync';
-import type * as Y from 'yjs';
+import type {
+	ObjectID,
+	ObjectType,
+	ProviderCreator,
+	ProviderCreatorOptions,
+	ProviderCreatorResult,
+	ProviderEventMap,
+	SyncConnectionState,
+} from '@wordpress/sync';
 
 export interface WebSocketConnectionConfig {
 	options?: WebsocketProviderOptions;
 	serverUrl: string;
 }
 
-const defaultResult = {
+const defaultResult: ProviderCreatorResult = {
 	destroy: () => {},
+	on: () => {},
 };
 
 /**
@@ -174,13 +182,25 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 		},
 	};
 
-	return async function ( objectType: ObjectType, objectId: ObjectID | null, doc: Y.Doc ) {
+	return async function ( {
+		objectType,
+		objectId,
+		ydoc,
+	}: ProviderCreatorOptions ): Promise< ProviderCreatorResult > {
+		// Store status listeners registered via the on() method.
+		const statusListeners: Array< ( state: SyncConnectionState ) => void > = [];
+
+		const emitStatus = ( state: SyncConnectionState ): void => {
+			statusListeners.forEach( listener => listener( state ) );
+		};
+
 		try {
 			// For now, we only support collections and traditional post types.
-			if (
+			const isUnsupportedObjectType =
 				null !== objectId &&
-				( ! objectType.startsWith( 'postType/' ) || ! parseInt( objectId, 10 ) )
-			) {
+				( ! objectType.startsWith( 'postType/' ) || ! parseInt( objectId, 10 ) );
+
+			if ( isUnsupportedObjectType ) {
 				logger.debug( 'WebSocket connection skipped for unsupported object', {
 					objectType,
 					objectId,
@@ -197,9 +217,9 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 			 * adding the blog ID to the room name as that won't be needed.
 			 */
 			const roomName = `site-${ BLOG_ID ?? 1 }/${ objectType }-${ objectId ?? 'collection' }`;
-			const awareness = await createAwareness( objectType, objectId, doc );
+			const awareness = await createAwareness( objectType, objectId, ydoc );
 			const options = { ...config.options, awareness };
-			const provider = new WebsocketProvider( config.serverUrl, roomName, doc, options );
+			const provider = new WebsocketProvider( config.serverUrl, roomName, ydoc, options );
 			const connect = createConnect( provider, objectType, objectId ?? 'collection' );
 
 			provider.on( 'connection-close', connect );
@@ -207,14 +227,23 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 				// The provider does not change status on connection error, so we
 				// manually trigger a synthetic status change.
 				onStatusChange( objectType, objectId, { status: 'connection-error' } );
+				emitStatus( { status: 'disconnected' } );
 			} );
-			provider.on( 'status', event => onStatusChange( objectType, objectId, event ) );
+
+			provider.on( 'status', event => {
+				onStatusChange( objectType, objectId, event );
+				emitStatus( {
+					status: event.status === 'connected' ? 'connected' : 'disconnected',
+				} );
+			} );
 
 			// Provide some debugging functions in development mode.
 			if ( isDevelopment() ) {
 				window.VIP_RTC.debug.disconnectWebSocket = () => {
 					provider.off( 'connection-close', connect );
 					provider.disconnect();
+					onStatusChange( objectType, objectId, { status: 'disconnected' } );
+					emitStatus( { status: 'disconnected' } );
 				};
 
 				window.VIP_RTC.debug.reconnectWebSocket = () => {
@@ -227,6 +256,14 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 
 			return {
 				destroy: () => provider.destroy(),
+				on: < K extends keyof ProviderEventMap >(
+					event: K,
+					callback: ( data: ProviderEventMap[ K ] ) => void
+				) => {
+					if ( event === 'status' ) {
+						statusListeners.push( callback as ( state: SyncConnectionState ) => void );
+					}
+				},
 			};
 		} catch ( err ) {
 			logger.critical( 'Failed to create WebSocket connection', { error: err } );

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -242,8 +242,6 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 				window.VIP_RTC.debug.disconnectWebSocket = () => {
 					provider.off( 'connection-close', connect );
 					provider.disconnect();
-					onStatusChange( objectType, objectId, { status: 'disconnected' } );
-					emitStatus( { status: 'disconnected' } );
 				};
 
 				window.VIP_RTC.debug.reconnectWebSocket = () => {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -23,8 +23,7 @@ import type {
 	ProviderCreator,
 	ProviderCreatorOptions,
 	ProviderCreatorResult,
-	ProviderEventMap,
-	SyncConnectionState,
+	SyncConnectionStatus,
 } from '@wordpress/sync';
 
 export interface WebSocketConnectionConfig {
@@ -84,18 +83,16 @@ function logInspectUrl( provider: WebsocketProvider ): void {
 	logger.info( `Yjs inspector for ${ provider.roomname }: ${ inspectUrl }` );
 }
 
+/**
+ * This is an event listener that responds to status events.
+ */
 function onStatusChange(
 	objectType: ObjectType,
 	objectId: ObjectID | null,
-	event: { status: 'connected' | 'connecting' | 'connection-error' | 'disconnected' }
+	event: { status: SyncConnectionStatus | 'connecting' | 'connection-error' }
 ): void {
 	switch ( event.status ) {
 		case 'connecting': {
-			break;
-		}
-
-		case 'connection-error': {
-			setConnectionStatus( objectType, objectId, false );
 			break;
 		}
 
@@ -187,13 +184,6 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 		objectId,
 		ydoc,
 	}: ProviderCreatorOptions ): Promise< ProviderCreatorResult > {
-		// Store status listeners registered via the on() method.
-		const statusListeners: Array< ( state: SyncConnectionState ) => void > = [];
-
-		const emitStatus = ( state: SyncConnectionState ): void => {
-			statusListeners.forEach( listener => listener( state ) );
-		};
-
 		try {
 			// For now, we only support collections and traditional post types.
 			const isUnsupportedObjectType =
@@ -225,16 +215,12 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 			provider.on( 'connection-close', connect );
 			provider.on( 'connection-error', () => {
 				// The provider does not change status on connection error, so we
-				// manually trigger a synthetic status change.
-				onStatusChange( objectType, objectId, { status: 'connection-error' } );
-				emitStatus( { status: 'disconnected' } );
+				// manually emit a "disconnected" status.
+				provider.emit( 'status', [ { status: 'disconnected' } ] );
 			} );
 
 			provider.on( 'status', event => {
 				onStatusChange( objectType, objectId, event );
-				emitStatus( {
-					status: event.status === 'connected' ? 'connected' : 'disconnected',
-				} );
 			} );
 
 			// Provide some debugging functions in development mode.
@@ -268,14 +254,7 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 
 			return {
 				destroy: () => provider.destroy(),
-				on: < K extends keyof ProviderEventMap >(
-					event: K,
-					callback: ( data: ProviderEventMap[ K ] ) => void
-				) => {
-					if ( event === 'status' ) {
-						statusListeners.push( callback as ( state: SyncConnectionState ) => void );
-					}
-				},
+				on: ( event, callback ) => provider.on( event, callback ),
 			};
 		} catch ( err ) {
 			logger.critical( 'Failed to create WebSocket connection', { error: err } );

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -13,14 +13,41 @@ declare module '@wordpress/sync' {
 	const CRDT_RECORD_METADATA_SAVED_AT_KEY: string;
 	const CRDT_RECORD_METADATA_SAVED_BY_KEY: string;
 
+	type SyncConnectionStatus = 'connected' | 'disconnected';
+
+	interface SyncConnectionError {
+		code: string;
+		message?: string;
+		description?: string;
+	}
+
+	interface SyncConnectionState {
+		status: SyncConnectionStatus;
+		error?: SyncConnectionError;
+	}
+
+	interface ProviderEventMap {
+		status: SyncConnectionState;
+	}
+
+	type ProviderOn = < K extends keyof ProviderEventMap >(
+		event: K,
+		callback: ( data: ProviderEventMap[ K ] ) => void
+	) => void;
+
+	interface ProviderCreatorOptions {
+		objectType: ObjectType;
+		objectId: ObjectID | null;
+		ydoc: Y.Doc;
+		awareness?: Awareness;
+	}
+
 	interface ProviderCreatorResult {
 		destroy: () => void;
+		on: ProviderOn;
 	}
 
 	type ProviderCreator = (
-		objectType: ObjectType,
-		objectId: ObjectID,
-		ydoc: Y.Doc,
-		awareness?: Awareness
+		options: ProviderCreatorOptions
 	) => Promise< ProviderCreatorResult >;
 }

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -13,7 +13,7 @@ declare module '@wordpress/sync' {
 	const CRDT_RECORD_METADATA_SAVED_AT_KEY: string;
 	const CRDT_RECORD_METADATA_SAVED_BY_KEY: string;
 
-	type SyncConnectionStatus = 'connected' | 'disconnected';
+	type SyncConnectionStatus = 'connected' | 'connecting' | 'disconnected';
 
 	interface SyncConnectionError {
 		code: string;

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -47,7 +47,5 @@ declare module '@wordpress/sync' {
 		on: ProviderOn;
 	}
 
-	type ProviderCreator = (
-		options: ProviderCreatorOptions
-	) => Promise< ProviderCreatorResult >;
+	type ProviderCreator = ( options: ProviderCreatorOptions ) => Promise< ProviderCreatorResult >;
 }


### PR DESCRIPTION
Fixes a plugin error `provider.on is not a function` caused by error handling type changes in https://github.com/WordPress/gutenberg/pull/74075. The root cause is that the `ProviderCreator` type changed from an argument list to [an options object](https://github.com/Automattic/gutenberg/blob/70092462d4509b8d41c59b31fcf2fac0c9e0e504/packages/sync/src/types.ts#L110-L115).

Additionally, this PR starts adding support for the Gutenberg-based error dialog by:

1. Adding new types from the sync package
2. Returning an `on()` function that the websocket provider sends events to

This fixes the immediate problem loading posts, but there are still some unimplemented parts:

1. Removal of the local `<PostLockedModal>`, which is provided by Gutenberg in https://github.com/WordPress/gutenberg/pull/74075. We should just be able to send events from the provider and remove the local modal.
2. Provider handling of unrecoverable errors - we still just try reconnecting regardless of the reason.