### PR TITLE
Allow plugin to work with `trunk` and plugin branch of Gutenberg

### DIFF
--- a/src/components/rtc-settings-panel.tsx
+++ b/src/components/rtc-settings-panel.tsx
@@ -74,25 +74,31 @@ export function RTCSettingsPanel() {
 
 	return (
 		<>
-			{ isAvatarsEnabled && (
+			{ isAvatarsEnabled && EditorPresence && (
 				<EditorPresence>
 					<Avatars cursorRegistry={ cursorRegistry.current } />
 				</EditorPresence>
 			) }
-			<BlockCanvasCover.Fill>
-				{ ( { containerRef }: { containerRef: React.MutableRefObject< HTMLElement | null > } ) => (
-					<>
-						<RTCOverlay
-							blockEditorDocument={ containerRef.current?.ownerDocument }
-							cursorRegistry={ cursorRegistry.current }
-						/>
-						{ isDebugToolsEnabled && containerRef.current?.ownerDocument && (
-							<DebugTools iframeDocument={ containerRef.current?.ownerDocument } />
-						) }
-						<PostLockedModal />
-					</>
-				) }
-			</BlockCanvasCover.Fill>
+			{ BlockCanvasCover && BlockCanvasCover.Fill && (
+				<BlockCanvasCover.Fill>
+					{ ( {
+						containerRef,
+					}: {
+						containerRef: React.MutableRefObject< HTMLElement | null >;
+					} ) => (
+						<>
+							<RTCOverlay
+								blockEditorDocument={ containerRef.current?.ownerDocument }
+								cursorRegistry={ cursorRegistry.current }
+							/>
+							{ isDebugToolsEnabled && containerRef.current?.ownerDocument && (
+								<DebugTools iframeDocument={ containerRef.current?.ownerDocument } />
+							) }
+							<PostLockedModal />
+						</>
+					) }
+				</BlockCanvasCover.Fill>
+			) }
 			<PostLockedModal />
 			<PluginDocumentSettingPanel
 				name="vip-real-time-collaboration"

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -180,6 +180,7 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 	};
 
 	return async function ( {
+		awareness,
 		objectType,
 		objectId,
 		ydoc,
@@ -207,8 +208,10 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 			 * adding the blog ID to the room name as that won't be needed.
 			 */
 			const roomName = `site-${ BLOG_ID ?? 1 }/${ objectType }-${ objectId ?? 'collection' }`;
-			const awareness = await createAwareness( objectType, objectId, ydoc );
-			const options = { ...config.options, awareness };
+			const options = {
+				...config.options,
+				awareness: awareness ?? ( await createAwareness( objectType, objectId, ydoc ) ),
+			};
 			const provider = new WebsocketProvider( config.serverUrl, roomName, ydoc, options );
 			const connect = createConnect( provider, objectType, objectId ?? 'collection' );
 

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -13,6 +13,8 @@ declare module '@wordpress/sync' {
 	const CRDT_RECORD_METADATA_SAVED_AT_KEY: string;
 	const CRDT_RECORD_METADATA_SAVED_BY_KEY: string;
 
+	type AwarenessState = Awareness;
+
 	type SyncConnectionStatus = 'connected' | 'connecting' | 'disconnected';
 
 	interface SyncConnectionError {
@@ -36,10 +38,10 @@ declare module '@wordpress/sync' {
 	) => void;
 
 	interface ProviderCreatorOptions {
+		awareness?: AwarenessState;
 		objectType: ObjectType;
 		objectId: ObjectID | null;
 		ydoc: Y.Doc;
-		awareness?: Awareness;
 	}
 
 	interface ProviderCreatorResult {


### PR DESCRIPTION
As we merge awareness into Gutenberg `trunk`, some guards will help us run against both branches.

Note: If you are running against Gutenberg `trunk`, it will currently still require cherry-picking this commit:

https://github.com/WordPress/gutenberg/commit/05400df5f21be8cf3471bf27684b0174f1a97825