### PR TITLE
Consume Yjs from private API

### DIFF
--- a/src/yjs-shim.ts
+++ b/src/yjs-shim.ts
@@ -1,0 +1,42 @@
+/**
+ * This file is a shim for loading Yjs from private APIs provided by the
+ * `@wordpress/sync` package. This is done primarily to avoid packaging and
+ * importing two different Yjs instances, which would result in this conflict:
+ *
+ * https://github.com/yjs/yjs/issues/438
+ *
+ * It also allows us to align on the same Yjs version automatically.
+ *
+ * Scripts in this repo should directly import 'yjs' which will resolve to this
+ * file via Webpack.
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { privateApis as syncPrivateApis, type SyncPrivateApis } from '@wordpress/sync';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/sync'
+);
+
+const { Y: Yjs } = unlock< SyncPrivateApis >( syncPrivateApis );
+
+// Functions
+export const applyUpdate = Yjs.applyUpdate;
+export const encodeStateVector = Yjs.encodeStateVector;
+export const encodeStateAsUpdate = Yjs.encodeStateAsUpdate;
+export const createRelativePositionFromTypeIndex = Yjs.createRelativePositionFromTypeIndex;
+
+// Shared types
+export const Doc = Yjs.Doc;
+export const Map = Yjs.Map;
+export const Array = Yjs.Array;
+export const Text = Yjs.Text;
+export const XmlElement = Yjs.XmlElement;
+export const XmlFragment = Yjs.XmlFragment;
+export const XmlText = Yjs.XmlText;
+
+// Utility types
+export const RelativePosition = Yjs.RelativePosition;
+export const AbsolutePosition = Yjs.AbsolutePosition;
+export const Snapshot = Yjs.Snapshot;
+export const UndoManager = Yjs.UndoManager;

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -1,10 +1,16 @@
 /**
+ * WordPress dependencies
+ */
+import type { PrivateApis } from '@wordpress/private-apis';
+
+/**
  * External dependencies
  */
 import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 
 declare module '@wordpress/sync' {
+	type CRDTDoc = Y.Doc;
 	type ObjectID = string;
 	type ObjectType = string;
 
@@ -50,4 +56,10 @@ declare module '@wordpress/sync' {
 	}
 
 	type ProviderCreator = ( options: ProviderCreatorOptions ) => Promise< ProviderCreatorResult >;
+
+	interface SyncPrivateApis {
+		Y: typeof Y;
+	}
+
+	const privateApis: PrivateApis< SyncPrivateApis >;
 }

--- a/webpack.utils.js
+++ b/webpack.utils.js
@@ -18,14 +18,6 @@ function modernize( config, additionalScripts = {}, additionalPlugins = [], watc
 			...config.externals,
 			// Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
 			'@wordpress/sync': 'wp.sync',
-
-			// Resolve Yjs to the global `wp.sync.Y` provided by the sync package.
-			// Since dependencies import 'yhs' directly, we need to avoid importing
-			// and packaging two different Yjs instances, which would result in this
-			// conflict:
-			//
-			// https://github.com/yjs/yjs/issues/438
-			yjs: 'wp.sync.Y',
 		},
 		module: {
 			rules: config.module.rules.concat( [
@@ -48,6 +40,7 @@ function modernize( config, additionalScripts = {}, additionalPlugins = [], watc
 			alias: {
 				...config.resolve.alias,
 				'@': path.resolve( __dirname, 'src/' ),
+				yjs: path.resolve( __dirname, 'src/yjs-shim.ts' ),
 			},
 		},
 		watchOptions: { ...config.watchOptions, ...watchOptions },


### PR DESCRIPTION
Consume Yjs from private API. Companion to https://github.com/WordPress/gutenberg/pull/74958