### PR TITLE
Add meta sync for third-party plugins (Yoast SEO)

### DIFF
--- a/inc/Compatibility/MetaCompatibility.php
+++ b/inc/Compatibility/MetaCompatibility.php
@@ -1,0 +1,265 @@
+<?php declare(strict_types = 1);
+
+namespace VIPRealTimeCollaboration\Compatibility;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Enables third-party plugin meta fields to work with Gutenberg's core-data store
+ * by forcing show_in_rest: true on whitelisted meta keys.
+ *
+ * This class works in conjunction with the JavaScript meta-sync module which
+ * bridges third-party plugin stores (like Yoast SEO) to core-data, enabling
+ * real-time collaboration for plugins that don't natively use core-data.
+ *
+ * @see https://developer.wordpress.org/block-editor/how-to-guides/metabox/
+ */
+final class MetaCompatibility {
+	/**
+	 * Default meta keys to enable for REST API access.
+	 *
+	 * These keys have corresponding JavaScript bridges in the meta-sync module
+	 * that handle real-time synchronization. To add custom meta keys, use:
+	 *
+	 * ```php
+	 * add_filter( 'vip_rtc_meta_whitelist', function( $keys ) {
+	 *     $keys[] = '_my_plugin_meta_key';
+	 *     return $keys;
+	 * } );
+	 * ```
+	 *
+	 * Note: Custom meta keys also need a JavaScript bridge to sync in real-time.
+	 *
+	 * @var array<string>
+	 */
+	private const DEFAULT_META_WHITELIST = [
+		// Yoast SEO meta keys (synced via yoast-seo-bridge.ts)
+		'_yoast_wpseo_title',
+		'_yoast_wpseo_metadesc',
+		'_yoast_wpseo_focuskw',
+	];
+
+	/**
+	 * Cached whitelist after applying filters.
+	 *
+	 * @var array<string>|null
+	 */
+	private static ?array $meta_whitelist = null;
+
+	/**
+	 * Constructor to initialize the meta compatibility hooks.
+	 */
+	public function __construct() {
+		// Hook early to intercept meta registration.
+		add_filter( 'register_meta_args', [ $this, 'maybe_enable_show_in_rest' ], 10, 4 );
+
+		// Handle already-registered meta on init (late priority).
+		add_action( 'init', [ $this, 'update_existing_meta_registration' ], 999 );
+	}
+
+	/**
+	 * Get the whitelist of meta keys to enable for REST API.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_meta_whitelist(): array {
+		if ( null !== self::$meta_whitelist ) {
+			return self::$meta_whitelist;
+		}
+
+		/**
+		 * Filter the list of meta keys to enable for REST API sync.
+		 *
+		 * @param array<string> $meta_keys Array of meta key names to enable.
+		 * @psalm-suppress MixedAssignment WordPress apply_filters returns mixed.
+		 */
+		$filtered = apply_filters(
+			'vip_rtc_meta_whitelist',
+			self::DEFAULT_META_WHITELIST
+		);
+
+		$whitelist = is_array( $filtered ) ? array_filter( $filtered, 'is_string' ) : self::DEFAULT_META_WHITELIST;
+
+		self::$meta_whitelist = $whitelist;
+
+		return self::$meta_whitelist;
+	}
+
+	/**
+	 * Check if a meta key should be enabled for REST API access.
+	 *
+	 * @param string $meta_key The meta key to check.
+	 */
+	public static function is_meta_whitelisted( string $meta_key ): bool {
+		return in_array( $meta_key, self::get_meta_whitelist(), true );
+	}
+
+	/**
+	 * Filter callback to enable show_in_rest for whitelisted meta keys.
+	 *
+	 * @param array<string, mixed> $args        Array of arguments for registering the meta key.
+	 * @param array<string, mixed> $defaults    Array of default values for the register_meta() args.
+	 * @param string               $object_type Type of object (post, comment, term, user).
+	 * @param string               $meta_key    Meta key being registered.
+	 * @return array<string, mixed> Modified arguments.
+	 *
+	 * @psalm-suppress PossiblyUnusedReturnValue Return value used by WordPress filter.
+	 * @psalm-suppress UnusedParam $defaults required by filter signature.
+	 */
+	public function maybe_enable_show_in_rest( array $args, array $defaults, string $object_type, string $meta_key ): array {
+		// Only process post meta.
+		if ( 'post' !== $object_type ) {
+			return $args;
+		}
+
+		// Check if this meta key is whitelisted.
+		if ( ! self::is_meta_whitelisted( $meta_key ) ) {
+			return $args;
+		}
+
+		// Skip if already enabled.
+		if ( ! empty( $args['show_in_rest'] ) ) {
+			return $args;
+		}
+
+		/**
+		 * Filter whether to enable a specific meta key for REST API.
+		 *
+		 * @param bool                 $enable   Whether to enable the meta key.
+		 * @param string               $meta_key The meta key.
+		 * @param array<string, mixed> $args     The registration arguments.
+		 */
+		$enable = (bool) apply_filters( 'vip_rtc_enable_meta_key', true, $meta_key, $args );
+
+		if ( ! $enable ) {
+			return $args;
+		}
+
+		// Enable show_in_rest and set safe defaults.
+		$args['show_in_rest'] = true;
+		$args = self::ensure_rest_defaults( $args, $meta_key );
+
+		return $args;
+	}
+
+	/**
+	 * Update already-registered meta keys to enable show_in_rest.
+	 * Runs on init at priority 999 to catch meta registered earlier.
+	 */
+	public function update_existing_meta_registration(): void {
+		global $wp_meta_keys;
+
+		if ( ! is_array( $wp_meta_keys ) || ! isset( $wp_meta_keys['post'] ) ) {
+			return;
+		}
+
+		/** @psalm-suppress MixedAssignment Global $wp_meta_keys has mixed types. */
+		foreach ( $wp_meta_keys['post'] as $subtype => $meta_keys ) {
+			if ( ! is_array( $meta_keys ) ) {
+				continue;
+			}
+
+			/** @psalm-suppress MixedAssignment Global $wp_meta_keys has mixed types. */
+			foreach ( $meta_keys as $meta_key => $meta_args ) {
+				// Ensure meta_key is a string and meta_args is an array.
+				if ( ! is_string( $meta_key ) || ! is_array( $meta_args ) ) {
+					continue;
+				}
+
+				// Skip if not whitelisted.
+				if ( ! self::is_meta_whitelisted( $meta_key ) ) {
+					continue;
+				}
+
+				// Skip if already enabled.
+				if ( ! empty( $meta_args['show_in_rest'] ) ) {
+					continue;
+				}
+
+				/**
+				 * Filter whether to enable a specific existing meta key for REST API.
+				 *
+				 * @param bool   $enable   Whether to enable the meta key.
+				 * @param string $meta_key The meta key.
+				 * @param string $subtype  The post subtype ('' for all post types).
+				 */
+				$enable = (bool) apply_filters( 'vip_rtc_enable_existing_meta_key', true, $meta_key, $subtype );
+
+				if ( ! $enable ) {
+					continue;
+				}
+
+				// Update the global directly.
+				/** @psalm-suppress MixedArgumentTypeCoercion Global $wp_meta_keys has mixed types. */
+				$updated_args = self::ensure_rest_defaults( $meta_args, $meta_key );
+				$updated_args['show_in_rest'] = true;
+				/** @psalm-suppress MixedArrayOffset, MixedArrayAssignment Global $wp_meta_keys has mixed types. */
+				$wp_meta_keys['post'][ $subtype ][ $meta_key ] = $updated_args;
+			}
+		}
+	}
+
+	/**
+	 * Ensure proper defaults are set for REST API compatibility.
+	 *
+	 * @param array<string, mixed> $args     The meta registration arguments.
+	 * @param string               $meta_key The meta key (reserved for future use).
+	 * @return array<string, mixed> Modified arguments with safe defaults.
+	 *
+	 * @psalm-suppress UnusedParam $meta_key reserved for future per-key customization.
+	 */
+	private static function ensure_rest_defaults( array $args, string $meta_key ): array {
+		// Set type if not defined (defaults to string for safety).
+		if ( ! isset( $args['type'] ) || '' === $args['type'] ) {
+			$args['type'] = 'string';
+		}
+
+		// Ensure single is set (most plugin meta is single).
+		if ( ! isset( $args['single'] ) ) {
+			$args['single'] = true;
+		}
+
+		// Set a secure auth_callback if not defined.
+		if ( ! isset( $args['auth_callback'] ) ) {
+			/**
+			 * @psalm-suppress UnusedClosureParam Parameters required by auth_callback signature.
+			 */
+			// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Parameters required by auth_callback signature.
+			$args['auth_callback'] = static function (
+				bool $allowed,
+				string $meta_key,
+				int $object_id,
+				int $user_id,
+				string $cap,
+				array $caps
+			): bool {
+				// Only allow if user can edit the post.
+				return current_user_can( 'edit_post', $object_id );
+			};
+		}
+
+		// Ensure sanitize_callback is set for security.
+		if ( ! isset( $args['sanitize_callback'] ) ) {
+			/**
+			 * @psalm-suppress UnusedClosureParam Parameters required by sanitize_callback signature.
+			 */
+			$args['sanitize_callback'] = static function ( mixed $value, string $meta_key ): mixed { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+				if ( is_string( $value ) ) {
+					return sanitize_text_field( $value );
+				}
+				return $value;
+			};
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Reset the cached whitelist. Useful for testing.
+	 *
+	 * @psalm-suppress PossiblyUnusedMethod Used in tests.
+	 */
+	public static function reset(): void {
+		self::$meta_whitelist = null;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,14 @@ import { addFilter } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
 
 import { RTCSettingsPanel } from '@/components/rtc-settings-panel';
+import { getMetaSyncManager, createYoastSeoBridge } from '@/meta-sync';
 import { WEBSOCKET_URL } from '@/utilities/config';
 import { Logger } from '@/utilities/logger';
 import { createWebSocketConnection } from '@/websocket-client';
+
+// Register meta sync bridges for third-party plugins
+const metaSyncManager = getMetaSyncManager();
+metaSyncManager.registerBridge( createYoastSeoBridge() );
 
 addFilter( 'sync.providers', 'vip-rtc', () => {
 	// We already error check for the WebSocket URL in the main plugin file,

--- a/src/meta-sync/bridges/yoast-seo-bridge.test.ts
+++ b/src/meta-sync/bridges/yoast-seo-bridge.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock, type Mock } from 'node:test';
+
+import { createYoastSeoBridge } from './yoast-seo-bridge';
+
+describe( 'Yoast SEO Bridge', () => {
+	let mockConsoleLog: Mock< typeof console.log >;
+
+	beforeEach( () => {
+		mockConsoleLog = mock.method( console, 'log', () => {} );
+	} );
+
+	afterEach( () => {
+		mock.restoreAll();
+	} );
+
+	describe( 'createYoastSeoBridge', () => {
+		it( 'should return a bridge with correct id', () => {
+			const bridge = createYoastSeoBridge();
+			assert.strictEqual( bridge.id, 'yoast-seo' );
+		} );
+
+		it( 'should return a bridge with required methods', () => {
+			const bridge = createYoastSeoBridge();
+
+			assert.strictEqual( typeof bridge.isAvailable, 'function' );
+			assert.strictEqual( typeof bridge.getFields, 'function' );
+			assert.strictEqual( typeof bridge.subscribe, 'function' );
+		} );
+
+		it( 'should return three fields for Yoast meta keys', () => {
+			const bridge = createYoastSeoBridge();
+			const fields = bridge.getFields();
+
+			assert.strictEqual( fields.length, 3 );
+
+			const keys = fields.map( f => f.key );
+			assert.ok( keys.includes( '_yoast_wpseo_title' ) );
+			assert.ok( keys.includes( '_yoast_wpseo_metadesc' ) );
+			assert.ok( keys.includes( '_yoast_wpseo_focuskw' ) );
+		} );
+
+		it( 'should return false for isAvailable when Yoast store is not loaded', () => {
+			const bridge = createYoastSeoBridge();
+			// In test environment, Yoast store is not available
+			assert.strictEqual( bridge.isAvailable(), false );
+		} );
+	} );
+} );

--- a/src/meta-sync/bridges/yoast-seo-bridge.ts
+++ b/src/meta-sync/bridges/yoast-seo-bridge.ts
@@ -1,0 +1,216 @@
+/**
+ * Yoast SEO Bridge
+ *
+ * Connects Yoast SEO's internal state to the meta sync system,
+ * enabling real-time collaboration for SEO fields.
+ */
+
+import { select, subscribe, dispatch } from '@wordpress/data';
+
+import { Logger } from '@/utilities/logger';
+
+import type { MetaSyncBridge, MetaSyncField } from '../types';
+
+const logger = new Logger( 'yoast-seo-bridge' );
+
+/**
+ * Yoast SEO store name.
+ */
+const YOAST_STORE = 'yoast-seo/editor';
+
+/**
+ * Meta keys that Yoast uses.
+ */
+const YOAST_META_KEYS = {
+	title: '_yoast_wpseo_title',
+	metadesc: '_yoast_wpseo_metadesc',
+	focuskw: '_yoast_wpseo_focuskw',
+	canonical: '_yoast_wpseo_canonical',
+} as const;
+
+/**
+ * Type for WordPress data store selectors.
+ */
+type StoreSelectors = Record< string, ( () => unknown ) | undefined >;
+
+/**
+ * Type for post meta object.
+ */
+type PostMeta = Record< string, unknown >;
+
+/**
+ * Check if Yoast SEO is available.
+ */
+function isYoastAvailable(): boolean {
+	try {
+		const store = select( YOAST_STORE );
+		return store !== undefined && store !== null;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Get a value from Yoast's store.
+ */
+function getYoastValue( selector: string ): unknown {
+	try {
+		const store = select( YOAST_STORE ) as StoreSelectors | null;
+		if ( ! store ) {
+			return undefined;
+		}
+
+		const selectorFn = store[ selector ];
+		if ( typeof selectorFn === 'function' ) {
+			return selectorFn();
+		}
+
+		return undefined;
+	} catch ( error: unknown ) {
+		logger.debug( `Failed to get Yoast value for ${ selector }`, { error } );
+		return undefined;
+	}
+}
+
+/**
+ * Type for Yoast store dispatch with known actions.
+ */
+type YoastDispatch = {
+	updateData: ( data: { title?: string; description?: string; slug?: string } ) => void;
+	setFocusKeyword: ( keyword: string ) => void;
+};
+
+/**
+ * Update snippet editor data (title or description).
+ */
+function updateSnippetData( field: 'title' | 'description', value: unknown ): void {
+	try {
+		const storeDispatch = dispatch( YOAST_STORE ) as YoastDispatch | null;
+		if ( ! storeDispatch?.updateData ) {
+			logger.debug( 'updateData action not available' );
+			return;
+		}
+
+		storeDispatch.updateData( { [ field ]: value as string } );
+		logger.debug( `Called updateData for ${ field }` );
+	} catch ( error: unknown ) {
+		logger.debug( `Error updating snippet data: ${ field }`, { error } );
+	}
+}
+
+/**
+ * Set the focus keyword.
+ */
+function setFocusKeyword( value: unknown ): void {
+	try {
+		const storeDispatch = dispatch( YOAST_STORE ) as YoastDispatch | null;
+		if ( ! storeDispatch?.setFocusKeyword ) {
+			logger.debug( 'setFocusKeyword action not available' );
+			return;
+		}
+
+		storeDispatch.setFocusKeyword( value as string );
+		logger.debug( 'Called setFocusKeyword' );
+	} catch ( error: unknown ) {
+		logger.debug( 'Error setting focus keyword', { error } );
+	}
+}
+
+/**
+ * Also sync to core-data meta so it persists on save.
+ */
+function syncToCoreDataMeta( metaKey: string, value: unknown ): void {
+	try {
+		const editorSelect = select( 'core/editor' ) as {
+			getEditedPostAttribute: ( attr: string ) => PostMeta | undefined;
+		};
+		const currentMeta: PostMeta = editorSelect.getEditedPostAttribute( 'meta' ) ?? {};
+		const currentValue = currentMeta[ metaKey ];
+
+		// Only update if value changed
+		if ( currentValue !== value ) {
+			const editorDispatch = dispatch( 'core/editor' ) as {
+				editPost: ( edits: { meta: PostMeta } ) => void;
+			};
+			editorDispatch.editPost( {
+				meta: {
+					...currentMeta,
+					[ metaKey ]: value,
+				},
+			} );
+		}
+	} catch ( error: unknown ) {
+		logger.debug( `Failed to sync to core-data meta: ${ metaKey }`, { error } );
+	}
+}
+
+/**
+ * Create the Yoast SEO bridge.
+ */
+export function createYoastSeoBridge(): MetaSyncBridge {
+	const fields: MetaSyncField[] = [
+		{
+			key: YOAST_META_KEYS.title,
+			getValue: () => getYoastValue( 'getSnippetEditorTitle' ),
+			setValue: ( value: unknown ) => {
+				updateSnippetData( 'title', value );
+				syncToCoreDataMeta( YOAST_META_KEYS.title, value );
+			},
+		},
+		{
+			key: YOAST_META_KEYS.metadesc,
+			getValue: () => getYoastValue( 'getSnippetEditorDescription' ),
+			setValue: ( value: unknown ) => {
+				updateSnippetData( 'description', value );
+				syncToCoreDataMeta( YOAST_META_KEYS.metadesc, value );
+			},
+		},
+		{
+			key: YOAST_META_KEYS.focuskw,
+			getValue: () => getYoastValue( 'getFocusKeyphrase' ),
+			setValue: ( value: unknown ) => {
+				setFocusKeyword( value );
+				syncToCoreDataMeta( YOAST_META_KEYS.focuskw, value );
+			},
+		},
+	];
+
+	return {
+		id: 'yoast-seo',
+
+		isAvailable: isYoastAvailable,
+
+		getFields: () => fields,
+
+		subscribe: ( callback: ( key: string, value: unknown ) => void ) => {
+			// Track previous values to detect changes
+			const previousValues: Record< string, unknown > = {};
+
+			// Initialize previous values
+			for ( const field of fields ) {
+				previousValues[ field.key ] = field.getValue();
+			}
+
+			// Subscribe to WordPress data store changes
+			// Provided type is generic `Function`.
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			const unsubscribeFn: () => void = subscribe( () => {
+				if ( ! isYoastAvailable() ) {
+					return;
+				}
+
+				for ( const field of fields ) {
+					const currentValue = field.getValue();
+					const previousValue = previousValues[ field.key ];
+
+					if ( currentValue !== previousValue ) {
+						previousValues[ field.key ] = currentValue;
+						callback( field.key, currentValue );
+					}
+				}
+			} ) as () => void;
+
+			return unsubscribeFn;
+		},
+	};
+}

--- a/src/meta-sync/index.ts
+++ b/src/meta-sync/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Meta Sync Module
+ *
+ * Provides real-time synchronization for third-party plugin meta fields
+ * that don't use WordPress core-data.
+ */
+
+export { MetaSyncManager, getMetaSyncManager } from './meta-sync-manager';
+export { createYoastSeoBridge } from './bridges/yoast-seo-bridge';
+export type { MetaSyncBridge, MetaSyncField, MetaSyncState } from './types';

--- a/src/meta-sync/meta-sync-manager.test.ts
+++ b/src/meta-sync/meta-sync-manager.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock, type Mock } from 'node:test';
+
+import { MetaSyncManager } from './meta-sync-manager';
+
+import type { MetaSyncBridge, MetaSyncField } from './types';
+
+describe( 'MetaSyncManager', () => {
+	let manager: MetaSyncManager;
+	let mockConsoleLog: Mock< typeof console.log >;
+
+	beforeEach( () => {
+		manager = new MetaSyncManager();
+		mockConsoleLog = mock.method( console, 'log', () => {} );
+	} );
+
+	afterEach( () => {
+		mock.restoreAll();
+	} );
+
+	describe( 'registerBridge', () => {
+		it( 'should register a bridge', () => {
+			const bridge: MetaSyncBridge = {
+				id: 'test-bridge',
+				isAvailable: () => true,
+				getFields: () => [],
+				subscribe: () => () => {},
+			};
+
+			manager.registerBridge( bridge );
+
+			// The bridge is registered (internal state)
+			// We can verify by checking it's available during initialization
+			assert.ok( mockConsoleLog.mock.callCount() >= 0 );
+		} );
+	} );
+
+	describe( 'getState', () => {
+		it( 'should return empty object when not initialized', () => {
+			const state = manager.getState();
+			assert.deepStrictEqual( state, {} );
+		} );
+	} );
+
+	describe( 'destroy', () => {
+		it( 'should clear internal state', () => {
+			// After destroy, getState should return empty
+			manager.destroy();
+			const state = manager.getState();
+			assert.deepStrictEqual( state, {} );
+		} );
+	} );
+} );

--- a/src/meta-sync/meta-sync-manager.ts
+++ b/src/meta-sync/meta-sync-manager.ts
@@ -1,0 +1,288 @@
+/**
+ * Meta Sync Manager
+ *
+ * Manages synchronization of third-party plugin meta fields via Yjs.
+ * This enables real-time sync for plugins that don't use core-data.
+ */
+
+import { select, subscribe } from '@wordpress/data';
+
+import { Logger } from '@/utilities/logger';
+
+import type { MetaSyncBridge, MetaSyncState } from './types';
+import type * as Y from 'yjs';
+
+const META_SYNC_MAP_KEY = 'vip-rtc-meta';
+
+const logger = new Logger( 'meta-sync' );
+
+/**
+ * Type for WordPress editor store selectors.
+ */
+type EditorSelectors = {
+	getCurrentPostId: () => number | null;
+};
+
+/**
+ * The MetaSyncManager coordinates syncing meta between third-party plugins
+ * and the Yjs document that's shared between collaborators.
+ */
+export class MetaSyncManager {
+	private readonly bridges: MetaSyncBridge[] = [];
+	private activeBridges: MetaSyncBridge[] = [];
+	private readonly unsubscribers: Array< () => void > = [];
+	private yDoc: Y.Doc | null = null;
+	private yMap: Y.Map< unknown > | null = null;
+	private isApplyingRemoteChanges = false;
+	private postId: string | null = null;
+
+	/**
+	 * Register a bridge for a third-party plugin.
+	 * Note: Availability is checked at initialization time, not registration time,
+	 * because third-party plugin stores may not be loaded when our script runs.
+	 */
+	public registerBridge( bridge: MetaSyncBridge ): void {
+		this.bridges.push( bridge );
+		logger.debug( `Registered bridge: ${ bridge.id }` );
+	}
+
+	/**
+	 * Initialize the meta sync system with a Yjs document.
+	 */
+	public initialize( doc: Y.Doc, postId: string ): void {
+		logger.debug( `Initializing for post ${ postId }`, {
+			bridges: this.bridges.map( b => b.id ),
+		} );
+
+		if ( this.bridges.length === 0 ) {
+			logger.debug( 'No bridges registered, meta sync disabled' );
+			return;
+		}
+
+		// Filter to only available bridges (third-party stores may now be loaded)
+		const availableBridges = this.bridges.filter( bridge => {
+			const available = bridge.isAvailable();
+			logger.debug( `Bridge "${ bridge.id }" availability: ${ available }` );
+			return available;
+		} );
+
+		if ( availableBridges.length === 0 ) {
+			logger.debug( 'No available bridges after filtering, meta sync disabled' );
+			return;
+		}
+
+		this.yDoc = doc;
+		this.postId = postId;
+		this.yMap = doc.getMap< unknown >( META_SYNC_MAP_KEY );
+
+		// Subscribe to remote changes from Yjs
+		this.yMap.observe( this.handleYjsChanges.bind( this ) );
+
+		// Subscribe to local changes from each available bridge
+		for ( const bridge of availableBridges ) {
+			const unsubscribe = bridge.subscribe( this.handleLocalChange.bind( this ) );
+			this.unsubscribers.push( unsubscribe );
+		}
+
+		// Store available bridges for later use
+		this.activeBridges = availableBridges;
+
+		// Sync initial state from bridges to Yjs (if we're the first to connect)
+		this.syncInitialState();
+
+		logger.info(
+			`Meta sync initialized for post ${ postId } with ${ availableBridges.length } bridges`
+		);
+	}
+
+	/**
+	 * Sync initial state from all active bridges to Yjs.
+	 * Only writes values that don't already exist in Yjs.
+	 */
+	private syncInitialState(): void {
+		const yMap = this.yMap;
+		const yDoc = this.yDoc;
+
+		if ( ! yMap || ! yDoc ) {
+			return;
+		}
+
+		yDoc.transact( () => {
+			for ( const bridge of this.activeBridges ) {
+				for ( const field of bridge.getFields() ) {
+					const value = field.getValue();
+
+					// Only set if not already in Yjs (preserves remote state)
+					if ( ! yMap.has( field.key ) ) {
+						if ( value !== undefined && value !== null && value !== '' ) {
+							yMap.set( field.key, value );
+							logger.debug( `Initial sync: wrote ${ field.key } to yMap` );
+						}
+					} else {
+						// Apply existing Yjs value to local state
+						const remoteValue = yMap.get( field.key );
+						if ( remoteValue !== undefined ) {
+							this.isApplyingRemoteChanges = true;
+							try {
+								field.setValue( remoteValue );
+								logger.debug( `Applied remote value to local: ${ field.key }` );
+							} finally {
+								this.isApplyingRemoteChanges = false;
+							}
+						}
+					}
+				}
+			}
+		} );
+	}
+
+	/**
+	 * Handle changes from Yjs (remote changes from other collaborators).
+	 */
+	private handleYjsChanges( event: Y.YMapEvent< unknown > ): void {
+		// Skip if this change originated from us
+		if ( event.transaction.local ) {
+			return;
+		}
+
+		this.isApplyingRemoteChanges = true;
+
+		try {
+			for ( const [ key, change ] of event.changes.keys ) {
+				if ( change.action === 'delete' ) {
+					continue;
+				}
+
+				const value = this.yMap?.get( key );
+				logger.debug( `Applying remote value: ${ key }`, { value } );
+				this.applyValueToBridges( key, value );
+			}
+		} finally {
+			this.isApplyingRemoteChanges = false;
+		}
+	}
+
+	/**
+	 * Apply a value from Yjs to the appropriate bridge.
+	 */
+	private applyValueToBridges( key: string, value: unknown ): void {
+		for ( const bridge of this.activeBridges ) {
+			const field = bridge.getFields().find( f => f.key === key );
+			if ( field ) {
+				logger.debug( `Applying remote change: ${ key }`, { value } );
+				field.setValue( value );
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Handle local changes from a bridge (user edited something in the plugin).
+	 */
+	private handleLocalChange( key: string, value: unknown ): void {
+		// Skip if we're currently applying remote changes (prevents loops)
+		if ( this.isApplyingRemoteChanges ) {
+			return;
+		}
+
+		if ( ! this.yMap ) {
+			return;
+		}
+
+		// Check if value actually changed
+		const currentValue = this.yMap.get( key );
+		if ( currentValue === value ) {
+			return;
+		}
+
+		logger.debug( `Writing to yMap: ${ key }`, { value } );
+		this.yMap.set( key, value );
+	}
+
+	/**
+	 * Get the current synced state.
+	 */
+	public getState(): MetaSyncState {
+		if ( ! this.yMap ) {
+			return {};
+		}
+
+		const state: MetaSyncState = {};
+		this.yMap.forEach( ( value, key ) => {
+			state[ key ] = value;
+		} );
+
+		return state;
+	}
+
+	/**
+	 * Clean up subscriptions and references.
+	 */
+	public destroy(): void {
+		for ( const unsubscribe of this.unsubscribers ) {
+			unsubscribe();
+		}
+
+		this.unsubscribers.length = 0;
+		this.activeBridges = [];
+		this.yDoc = null;
+		this.yMap = null;
+		this.postId = null;
+
+		logger.info( 'Meta sync destroyed' );
+	}
+}
+
+// Singleton instance
+let metaSyncManager: MetaSyncManager | null = null;
+
+/**
+ * Get or create the MetaSyncManager singleton.
+ */
+export function getMetaSyncManager(): MetaSyncManager {
+	if ( ! metaSyncManager ) {
+		metaSyncManager = new MetaSyncManager();
+	}
+
+	return metaSyncManager;
+}
+
+/**
+ * Initialize meta sync when the editor loads.
+ * Call this after registering all bridges.
+ */
+export function initializeMetaSync(): void {
+	// Wait for the editor to be ready and get the Yjs doc
+	// We need to store unsubscribe in a mutable variable since we call it from within the callback
+	let unsubscribeFn: ( () => void ) | null = null;
+
+	const subscribeCallback = (): void => {
+		// Check if we have a current post
+		const editorSelect = select( 'core/editor' ) as EditorSelectors;
+		const postId = editorSelect.getCurrentPostId();
+		if ( ! postId ) {
+			return;
+		}
+
+		// Get the Yjs doc from WordPress sync
+		const wpSync = ( window as { wp?: { sync?: { Y?: unknown } } } ).wp?.sync;
+		if ( ! wpSync?.Y ) {
+			logger.debug( 'Yjs not available yet' );
+			return;
+		}
+
+		// We need access to the doc that's being used for sync
+		// This is available through the sync providers
+		// For now, we'll create our own map within the existing doc structure
+
+		if ( unsubscribeFn ) {
+			unsubscribeFn();
+		}
+
+		logger.info( 'Editor ready, meta sync will initialize when Yjs doc is available' );
+	};
+
+	// Provided type is generic `Function`.
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	unsubscribeFn = subscribe( subscribeCallback ) as () => void;
+}

--- a/src/meta-sync/types.ts
+++ b/src/meta-sync/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Types for the meta sync system.
+ */
+
+/**
+ * Configuration for a meta field to sync.
+ */
+export interface MetaSyncField {
+	/**
+	 * The meta key name (e.g., '_yoast_wpseo_title').
+	 */
+	key: string;
+
+	/**
+	 * Function to get the current value from the third-party plugin.
+	 */
+	getValue: () => unknown;
+
+	/**
+	 * Function to set the value in the third-party plugin.
+	 */
+	setValue: ( value: unknown ) => void;
+}
+
+/**
+ * A bridge connects a third-party plugin's state to the meta sync system.
+ */
+export interface MetaSyncBridge {
+	/**
+	 * Unique identifier for this bridge (e.g., 'yoast-seo').
+	 */
+	id: string;
+
+	/**
+	 * Check if the third-party plugin is available.
+	 */
+	isAvailable: () => boolean;
+
+	/**
+	 * Get the list of meta fields this bridge handles.
+	 */
+	getFields: () => MetaSyncField[];
+
+	/**
+	 * Subscribe to changes in the third-party plugin's state.
+	 * Returns an unsubscribe function.
+	 */
+	subscribe: ( callback: ( key: string, value: unknown ) => void ) => () => void;
+}
+
+/**
+ * Meta values stored in the Yjs document.
+ */
+export type MetaSyncState = Record< string, unknown >;

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { WebsocketProvider, type WebsocketProviderOptions } from 'y-websocket';
 
 import { createAwareness, setConnectionStatus } from '@/awareness/awareness-manager';
+import { getMetaSyncManager } from '@/meta-sync';
 import {
 	isDevelopment,
 	BLOG_ID,
@@ -225,8 +226,20 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 
 			await connect();
 
+			// Initialize meta sync for post types
+			if ( objectType.startsWith( 'postType/' ) && objectId ) {
+				const metaSyncManager = getMetaSyncManager();
+				metaSyncManager.initialize( doc, objectId );
+			}
+
 			return {
-				destroy: () => provider.destroy(),
+				destroy: () => {
+					// Clean up meta sync
+					if ( objectType.startsWith( 'postType/' ) && objectId ) {
+						getMetaSyncManager().destroy();
+					}
+					provider.destroy();
+				},
 			};
 		} catch ( err ) {
 			logger.critical( 'Failed to create WebSocket connection', { error: err } );

--- a/tests/Integration/Compatibility/MetaCompatibilityTest.php
+++ b/tests/Integration/Compatibility/MetaCompatibilityTest.php
@@ -1,0 +1,444 @@
+<?php declare(strict_types = 1);
+
+namespace VIPRealTimeCollaboration\Tests\Integration\Compatibility;
+
+use VIPRealTimeCollaboration\Compatibility\MetaCompatibility;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Integration Tests for the MetaCompatibility class.
+ */
+final class MetaCompatibilityTest extends TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		MetaCompatibility::reset();
+
+		// Clear any registered meta from previous tests.
+		global $wp_meta_keys;
+		unset( $wp_meta_keys['post'] );
+	}
+
+	public function tearDown(): void {
+		MetaCompatibility::reset();
+
+		// Clear any filters we added.
+		remove_all_filters( 'vip_rtc_meta_whitelist' );
+		remove_all_filters( 'vip_rtc_enable_meta_key' );
+		remove_all_filters( 'vip_rtc_enable_existing_meta_key' );
+
+		// Clear registered meta.
+		global $wp_meta_keys;
+		unset( $wp_meta_keys['post'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::get_meta_whitelist
+	 */
+	public function test_get_meta_whitelist_returns_default_yoast_keys(): void {
+		$whitelist = MetaCompatibility::get_meta_whitelist();
+
+		self::assertIsArray( $whitelist );
+		self::assertContains( '_yoast_wpseo_title', $whitelist );
+		self::assertContains( '_yoast_wpseo_metadesc', $whitelist );
+		self::assertContains( '_yoast_wpseo_focuskw', $whitelist );
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::get_meta_whitelist
+	 */
+	public function test_whitelist_can_be_filtered(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_custom_meta_key';
+			return $keys;
+		} );
+
+		$whitelist = MetaCompatibility::get_meta_whitelist();
+
+		self::assertContains( '_custom_meta_key', $whitelist );
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::is_meta_whitelisted
+	 */
+	public function test_is_meta_whitelisted_returns_true_for_whitelisted_keys(): void {
+		// Test with default Yoast key
+		self::assertTrue( MetaCompatibility::is_meta_whitelisted( '_yoast_wpseo_title' ) );
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::is_meta_whitelisted
+	 */
+	public function test_is_meta_whitelisted_returns_false_for_non_whitelisted_keys(): void {
+		self::assertFalse( MetaCompatibility::is_meta_whitelisted( '_some_random_meta' ) );
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_enables_show_in_rest_for_whitelisted_keys(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_test_meta_key', [
+			'single' => true,
+			'type' => 'string',
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertTrue(
+			$wp_meta_keys['post']['post']['_test_meta_key']['show_in_rest'],
+			'Whitelisted meta should have show_in_rest enabled'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_does_not_enable_for_non_whitelisted_keys(): void {
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_some_other_meta', [
+			'single' => true,
+			'type' => 'string',
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertEmpty(
+			$wp_meta_keys['post']['post']['_some_other_meta']['show_in_rest'] ?? null,
+			'Non-whitelisted meta should not have show_in_rest enabled'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_does_not_override_existing_show_in_rest(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_test_meta_key', [
+			'single' => true,
+			'type' => 'string',
+			'show_in_rest' => [
+				'schema' => [
+					'type' => 'string',
+					'context' => [ 'view', 'edit' ],
+				],
+			],
+		] );
+
+		global $wp_meta_keys;
+
+		// Should preserve the original complex show_in_rest config.
+		self::assertIsArray(
+			$wp_meta_keys['post']['post']['_test_meta_key']['show_in_rest'],
+			'Should preserve existing show_in_rest configuration'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_sets_secure_auth_callback(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_test_meta_key', [
+			'single' => true,
+			'type' => 'string',
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertIsCallable(
+			$wp_meta_keys['post']['post']['_test_meta_key']['auth_callback'],
+			'Should set an auth_callback'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_sets_sanitize_callback(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_test_meta_key', [
+			'single' => true,
+			'type' => 'string',
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertIsCallable(
+			$wp_meta_keys['post']['post']['_test_meta_key']['sanitize_callback'],
+			'Should set a sanitize_callback'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_does_not_override_existing_auth_callback(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		$custom_callback = function (): bool {
+			return false;
+		};
+
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_test_meta_key', [
+			'single' => true,
+			'type' => 'string',
+			'auth_callback' => $custom_callback,
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertSame(
+			$custom_callback,
+			$wp_meta_keys['post']['post']['_test_meta_key']['auth_callback'],
+			'Should preserve existing auth_callback'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_sets_default_type_if_not_provided(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_test_meta_key', [
+			'single' => true,
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertSame(
+			'string',
+			$wp_meta_keys['post']['post']['_test_meta_key']['type'],
+			'Should set default type to string'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_enable_meta_key_filter_can_disable(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		add_filter( 'vip_rtc_enable_meta_key', function ( bool $enable, string $meta_key ): bool {
+			if ( '_test_meta_key' === $meta_key ) {
+				return false;
+			}
+			return $enable;
+		}, 10, 2 );
+
+		new MetaCompatibility();
+
+		register_post_meta( 'post', '_test_meta_key', [
+			'single' => true,
+			'type' => 'string',
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertFalse(
+			$wp_meta_keys['post']['post']['_test_meta_key']['show_in_rest'] ?? false,
+			'Filter should be able to disable show_in_rest'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::maybe_enable_show_in_rest
+	 */
+	public function test_only_processes_post_object_type(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		new MetaCompatibility();
+
+		// Add a whitelisted key to the user object type (should not be modified).
+		register_meta( 'user', '_test_meta_key', [
+			'single' => true,
+			'type' => 'string',
+		] );
+
+		global $wp_meta_keys;
+
+		self::assertEmpty(
+			$wp_meta_keys['user']['']['_test_meta_key']['show_in_rest'] ?? null,
+			'Should not modify meta for non-post object types'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::update_existing_meta_registration
+	 */
+	public function test_updates_existing_meta_registration(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		global $wp_meta_keys;
+
+		// Simulate meta already registered before our plugin.
+		$wp_meta_keys['post']['']['_test_meta_key'] = [
+			'single' => true,
+			'type' => 'string',
+			'show_in_rest' => false,
+		];
+
+		$compat = new MetaCompatibility();
+		$compat->update_existing_meta_registration();
+
+		self::assertTrue(
+			$wp_meta_keys['post']['']['_test_meta_key']['show_in_rest'],
+			'Existing whitelisted meta should be updated'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::update_existing_meta_registration
+	 */
+	public function test_update_existing_does_not_modify_non_whitelisted(): void {
+		global $wp_meta_keys;
+
+		// Simulate meta already registered before our plugin.
+		$wp_meta_keys['post']['']['_some_random_meta'] = [
+			'single' => true,
+			'type' => 'string',
+			'show_in_rest' => false,
+		];
+
+		$compat = new MetaCompatibility();
+		$compat->update_existing_meta_registration();
+
+		self::assertFalse(
+			$wp_meta_keys['post']['']['_some_random_meta']['show_in_rest'],
+			'Non-whitelisted meta should not be modified'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::update_existing_meta_registration
+	 */
+	public function test_update_existing_respects_filter(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		global $wp_meta_keys;
+
+		add_filter( 'vip_rtc_enable_existing_meta_key', function ( bool $enable, string $meta_key ): bool {
+			if ( '_test_meta_key' === $meta_key ) {
+				return false;
+			}
+			return $enable;
+		}, 10, 2 );
+
+		// Simulate meta already registered before our plugin.
+		$wp_meta_keys['post']['']['_test_meta_key'] = [
+			'single' => true,
+			'type' => 'string',
+			'show_in_rest' => false,
+		];
+
+		$compat = new MetaCompatibility();
+		$compat->update_existing_meta_registration();
+
+		self::assertFalse(
+			$wp_meta_keys['post']['']['_test_meta_key']['show_in_rest'],
+			'Filter should prevent updating existing meta'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::update_existing_meta_registration
+	 */
+	public function test_update_existing_skips_already_enabled(): void {
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_test_meta_key';
+			return $keys;
+		} );
+
+		global $wp_meta_keys;
+
+		// Simulate meta already registered with custom show_in_rest config.
+		$wp_meta_keys['post']['']['_test_meta_key'] = [
+			'single' => true,
+			'type' => 'string',
+			'show_in_rest' => [
+				'schema' => [ 'type' => 'string' ],
+			],
+		];
+
+		$compat = new MetaCompatibility();
+		$compat->update_existing_meta_registration();
+
+		self::assertIsArray(
+			$wp_meta_keys['post']['']['_test_meta_key']['show_in_rest'],
+			'Should preserve existing show_in_rest configuration'
+		);
+	}
+
+	/**
+	 * @covers \VIPRealTimeCollaboration\Compatibility\MetaCompatibility::reset
+	 */
+	public function test_reset_clears_cached_whitelist(): void {
+		// First call caches the whitelist.
+		$whitelist1 = MetaCompatibility::get_meta_whitelist();
+
+		// Add a filter that would modify the whitelist.
+		add_filter( 'vip_rtc_meta_whitelist', function ( array $keys ): array {
+			$keys[] = '_new_meta_key';
+			return $keys;
+		} );
+
+		// Without reset, the cached version is returned.
+		$whitelist2 = MetaCompatibility::get_meta_whitelist();
+		self::assertSame( $whitelist1, $whitelist2, 'Cached whitelist should be returned' );
+
+		// After reset, the filter is applied.
+		MetaCompatibility::reset();
+		$whitelist3 = MetaCompatibility::get_meta_whitelist();
+		self::assertContains( '_new_meta_key', $whitelist3, 'Filter should be applied after reset' );
+	}
+}

--- a/vip-real-time-collaboration.php
+++ b/vip-real-time-collaboration.php
@@ -17,6 +17,7 @@ use VIPRealTimeCollaboration\Api\RestApi;
 use VIPRealTimeCollaboration\Assets\Assets;
 use VIPRealTimeCollaboration\Auth\SyncPermissions;
 use VIPRealTimeCollaboration\Compatibility\Compatibility;
+use VIPRealTimeCollaboration\Compatibility\MetaCompatibility;
 use VIPRealTimeCollaboration\Settings\Settings;
 use VIPRealTimeCollaboration\Overrides\Overrides;
 
@@ -73,6 +74,7 @@ add_action( 'plugins_loaded', static function (): void {
 
 	new Assets();
 	new Overrides();
+	new MetaCompatibility();
 	new RestApi();
 
 	// Fire action to indicate that the plugin has loaded.


### PR DESCRIPTION
This adds real-time synchronization support for third-party plugin meta fields that don't use WordPress core-data. The implementation includes:

**PHP (MetaCompatibility.php):**
- Enables show_in_rest: true on whitelisted meta keys so they can be saved via REST API
- Hooks into register_meta_args filter to intercept meta registration
- Updates already-registered meta via wp_meta_keys global on init
- Sets secure defaults (auth_callback, sanitize_callback)
- Provides filter hooks for extensibility:
  - vip_rtc_meta_whitelist - Add meta keys to whitelist
  - vip_rtc_enable_meta_key - Per-key control during registration
  - vip_rtc_enable_existing_meta_key - Per-key control for existing meta

**JavaScript (meta-sync module):**
- MetaSyncManager class coordinates sync between plugin bridges and Yjs
- Bridge pattern allows adding support for any third-party plugin
- Yoast SEO bridge syncs title, meta description, and focus keyphrase
- Uses Yoast updateData() and setFocusKeyword() dispatch actions
- Also syncs to core-data meta for persistence on save

**How it works:**
1. User A edits Yoast SEO field
2. JS bridge detects change -> writes to Yjs -> syncs to User B
3. User B bridge receives change -> updates Yoast UI + core-data
4. When either saves, meta persists via REST API (enabled by PHP whitelist)