### PR TITLE
Accept tokens with either `connection_id` or `wp_client_id`

### DIFF
--- a/websocket-server/auth.test.ts
+++ b/websocket-server/auth.test.ts
@@ -37,6 +37,18 @@ describe( 'getWpClientId', () => {
 		assert.strictEqual( getWpClientId( request, MOCK_JWT_SECRET ), 'conn-456' );
 	} );
 
+	it( 'should return connection_id from valid token when wp_client_id is not present', () => {
+		const token = createValidToken( { connection_id: 'conn-789', wp_client_id: undefined } );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		assert.strictEqual( getWpClientId( request, MOCK_JWT_SECRET ), 'conn-789' );
+	} );
+
+	it( 'should prefer wp_client_id over connection_id when both are present', () => {
+		const token = createValidToken( { wp_client_id: 'wp-id', connection_id: 'conn-id' } );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		assert.strictEqual( getWpClientId( request, MOCK_JWT_SECRET ), 'wp-id' );
+	} );
+
 	it( 'should return null when token is missing', () => {
 		const request = createRequest( '/test-room' );
 		assert.strictEqual( getWpClientId( request, MOCK_JWT_SECRET ), null );
@@ -80,6 +92,13 @@ describe( 'isRequestAuthenticated', () => {
 
 	it( 'should return authenticated true for valid token and matching room', () => {
 		const token = createValidToken();
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, true );
+	} );
+
+	it( 'should return authenticated true for valid token with connection_id instead of wp_client_id', () => {
+		const token = createValidToken( { connection_id: 'conn-123', wp_client_id: undefined } );
 		const request = createRequest( `/test-room?auth=${ token }` );
 		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
 		assert.strictEqual( result.authenticated, true );
@@ -138,6 +157,17 @@ describe( 'isRequestAuthenticated', () => {
 			room_name: undefined,
 			user_id: undefined,
 			username: undefined,
+		} );
+		const request = createRequest( `/test-room?auth=${ token }` );
+		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );
+		assert.strictEqual( result.authenticated, false );
+		assert.strictEqual( result.reason, 'invalid_token' );
+	} );
+
+	it( 'should return invalid_token for token missing both connection_id and wp_client_id', () => {
+		const token = createValidToken( {
+			connection_id: undefined,
+			wp_client_id: undefined,
 		} );
 		const request = createRequest( `/test-room?auth=${ token }` );
 		const result = isRequestAuthenticated( request, MOCK_JWT_SECRET );

--- a/websocket-server/auth.ts
+++ b/websocket-server/auth.ts
@@ -14,10 +14,11 @@ interface AuthFailureResult {
 }
 
 export interface SyncTokenPayload extends JwtPayload {
-	wp_client_id: string;
+	connection_id?: string; // @deprecated
 	room_name: string;
 	user_id: number;
 	username: string;
+	wp_client_id: string;
 }
 
 function isSyncTokenPayload( payload: unknown ): payload is SyncTokenPayload {
@@ -27,7 +28,7 @@ function isSyncTokenPayload( payload: unknown ): payload is SyncTokenPayload {
 		'user_id' in payload &&
 		'username' in payload &&
 		'room_name' in payload &&
-		'wp_client_id' in payload
+		( 'connection_id' in payload || 'wp_client_id' in payload )
 	);
 }
 
@@ -76,7 +77,7 @@ export function getWpClientId( request: IncomingMessage, secret: string ): strin
 
 	try {
 		const jwtPayload = verifyToken( authToken, secret );
-		return jwtPayload.wp_client_id;
+		return jwtPayload.wp_client_id ?? jwtPayload.connection_id;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
Accept tokens with either `connection_id` or `wp_client_id` to bridge change in token payload format.