### PR TITLE
Fix error when collaboratorInfo is null

### DIFF
--- a/src/hooks/use-render-cursors.ts
+++ b/src/hooks/use-render-cursors.ts
@@ -45,14 +45,16 @@ export function useRenderCursors(
 				return;
 			}
 
-			const userSelections = sortedUsers.map( user => ( {
-				userName: user.collaboratorInfo.name,
-				clientId: user.clientId,
-				// Replace local user's selection with the current selection from the editor state.
-				selection: user.editorState?.selection ?? { type: SelectionType.None },
-				color: user.collaboratorInfo.color,
-				isMe: user.isMe,
-			} ) );
+			const userSelections = sortedUsers
+				.filter( user => user.collaboratorInfo )
+				.map( user => ( {
+					userName: user.collaboratorInfo.name,
+					clientId: user.clientId,
+					// Replace local user's selection with the current selection from the editor state.
+					selection: user.editorState?.selection ?? { type: SelectionType.None },
+					color: user.collaboratorInfo.color,
+					isMe: user.isMe,
+				} ) );
 
 			drawUserSelections(
 				overlayRef.current,


### PR DESCRIPTION
When retrieving collaborator info takes too long, the collaboratorInfo property can be null and cause exceptions. This change fixes that issue.

Companion Gutenberg PR: https://github.com/WordPress/gutenberg/pull/75401

See the testing instructions in the Gutenberg PR