### PR TITLE
Skip WebSocket sync when REST auth returns permission_denied

### DIFF
--- a/src/utilities/error.test.ts
+++ b/src/utilities/error.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { isForbiddenAuthError } from './error';
+
+describe( 'isForbiddenAuthError', () => {
+	it( 'returns true for permission_denied code', () => {
+		assert.strictEqual(
+			isForbiddenAuthError( { code: 'permission_denied', message: 'No' } ),
+			true
+		);
+	} );
+
+	it( 'returns false for unrelated errors', () => {
+		assert.strictEqual( isForbiddenAuthError( null ), false );
+		assert.strictEqual( isForbiddenAuthError( new Error( 'fail' ) ), false );
+		assert.strictEqual(
+			isForbiddenAuthError( {
+				code: 'rest_forbidden',
+				message: 'Forbidden',
+				data: { status: 403 },
+			} ),
+			false
+		);
+	} );
+} );

--- a/src/utilities/error.ts
+++ b/src/utilities/error.ts
@@ -2,6 +2,20 @@ import { __ } from '@wordpress/i18n';
 
 import type { ConnectionError } from '@wordpress/sync';
 
+/**
+ * True when the REST error is `permission_denied` from token generation (entity not syncable),
+ * matching "skip this room" handling in Gutenberg's sync providers.
+ *
+ * See: https://github.com/WordPress/gutenberg/pull/77242
+ */
+export function isForbiddenAuthError( error: unknown ): boolean {
+	if ( ! error || typeof error !== 'object' ) {
+		return false;
+	}
+
+	return ( error as { code?: unknown } ).code === 'permission_denied';
+}
+
 export function getErrorMessage( error: unknown, defaultMessage?: string ): string {
 	if ( error instanceof Error ) {
 		return error.message;

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -12,7 +12,7 @@ import {
 	WEBSOCKET_URL,
 } from '@/utilities/config';
 import { generateUUID } from '@/utilities/crypto';
-import { WebSocketError, getErrorMessage } from '@/utilities/error';
+import { WebSocketError, getErrorMessage, isForbiddenAuthError } from '@/utilities/error';
 import { memoizeFn } from '@/utilities/function';
 import { Logger } from '@/utilities/logger';
 import { SyncConnectionStatusEmitter } from '@/utilities/sync-event-emitter';
@@ -111,7 +111,8 @@ function getErrorFromCloseCode( code?: number ): ConnectionError {
 function createConnect(
 	provider: WebsocketProvider,
 	syncObjectType: string,
-	syncObjectId: string
+	syncObjectId: string,
+	initialAuthToken: string
 ): () => Promise< void > {
 	let reconnectAttempts = 0;
 
@@ -132,7 +133,10 @@ function createConnect(
 		reconnectAttempts += 1;
 
 		try {
-			const authToken = await fetchAuthToken( syncObjectType, syncObjectId );
+			const authToken =
+				reconnectAttempts === 1
+					? initialAuthToken
+					: await fetchAuthToken( syncObjectType, syncObjectId );
 
 			provider.params = {
 				auth: authToken,
@@ -146,12 +150,19 @@ function createConnect(
 
 			logInspectUrl( provider );
 		} catch ( error: unknown ) {
-			logger.error(
-				`${ __(
-					'Failed to fetch auth token and connect to WebSocket',
-					'vip-real-time-collaboration'
-				) }: ${ getErrorMessage( error ) }`
-			);
+			if ( isForbiddenAuthError( error ) ) {
+				logger.debug( 'WebSocket reconnect skipped: no permission for this sync object', {
+					syncObjectType,
+					syncObjectId,
+				} );
+			} else {
+				logger.error(
+					`${ __(
+						'Failed to fetch auth token and connect to WebSocket',
+						'vip-real-time-collaboration'
+					) }: ${ getErrorMessage( error ) }`
+				);
+			}
 		}
 	};
 }
@@ -203,12 +214,39 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 			 * adding the blog ID to the room name as that won't be needed.
 			 */
 			const roomName = `site-${ BLOG_ID ?? 1 }/${ objectType }-${ objectId ?? 'collection' }`;
+
+			let initialAuthToken: string;
+			try {
+				initialAuthToken = await fetchAuthToken( objectType, objectId ?? 'collection' );
+			} catch ( error: unknown ) {
+				if ( isForbiddenAuthError( error ) ) {
+					logger.debug( 'WebSocket connection skipped: user cannot sync this entity', {
+						objectType,
+						objectId,
+					} );
+					return defaultResult;
+				}
+
+				logger.error(
+					`${ __(
+						'Failed to fetch auth token and connect to WebSocket',
+						'vip-real-time-collaboration'
+					) }: ${ getErrorMessage( error ) }`
+				);
+				return defaultResult;
+			}
+
 			const options = {
 				...config.options,
 				awareness,
 			};
 			const provider = new WebsocketProvider( config.serverUrl, roomName, ydoc, options );
-			const connect = createConnect( provider, objectType, objectId ?? 'collection' );
+			const connect = createConnect(
+				provider,
+				objectType,
+				objectId ?? 'collection',
+				initialAuthToken
+			);
 
 			// Create a typed event emitter for our custom sync-connection-status event.
 			const syncStatusEmitter = new SyncConnectionStatusEmitter();


### PR DESCRIPTION
## Summary

Aligns the VIP WebSocket sync provider with [Gutenberg #77242](https://github.com/WordPress/gutenberg/pull/77242): when `/vip-rtc/v1/websocket/auth` returns `permission_denied` for a specific sync object (e.g. user cannot edit that entity), we return a no-op provider for that room instead of attaching `y-websocket` and treating it like a connection failure.

## Changes

- Add `isForbiddenAuthError()` for REST `code === 'permission_denied'`.
- Prefetch JWT before creating `WebsocketProvider`; reuse token on first connect.
- On reconnect, log forbidden token refresh at debug instead of error.

## Testing

- `npm run test:js:unit`
- `npm run check-types`

Made with [Cursor](https://cursor.com)