### PR TITLE
Add client-side per-room connection limit

### DIFF
--- a/src/components/collaboration-limit-modal.tsx
+++ b/src/components/collaboration-limit-modal.tsx
@@ -33,6 +33,18 @@ function getConnectionErrorMessage(
 	errorCode: ConnectionErrorCode | undefined,
 	isAdmin: boolean
 ): ConnectionErrorMessage {
+	if ( errorCode === 'room-limit-exceeded' ) {
+		// Client-side per-room connection cap. This yield is terminal — the
+		// client does not auto-reconnect — so the copy must not promise a retry.
+		return {
+			title: __( 'Too many open connections', 'vip-real-time-collaboration' ),
+			body: __(
+				'This page has reached its active collaborator limit.',
+				'vip-real-time-collaboration'
+			),
+		};
+	}
+
 	if ( errorCode === 'collaborator-limit-exceeded' ) {
 		return {
 			title: __( 'Collaborator limit reached', 'vip-real-time-collaboration' ),

--- a/src/components/collaboration-limit-modal.tsx
+++ b/src/components/collaboration-limit-modal.tsx
@@ -48,7 +48,7 @@ function getConnectionErrorMessage(
 	errorCode: ConnectionErrorCode | undefined,
 	isAdmin: boolean
 ): ConnectionErrorMessage {
-	if ( errorCode === 'room-limit-exceeded' ) {
+	if ( errorCode === 'room-connection-limit-exceeded' ) {
 		// Client-side per-room connection cap. This yield is terminal — the
 		// client does not auto-reconnect — so the copy must not promise a retry.
 		return {

--- a/src/constants/sync-errors.ts
+++ b/src/constants/sync-errors.ts
@@ -8,7 +8,7 @@ import type { ConnectionErrorCode } from '@wordpress/sync';
 export const CUSTOM_MODAL_ERROR_CODES: ReadonlyArray< ConnectionErrorCode > = [
 	'collaborator-limit-exceeded',
 	'connection-limit-exceeded',
-	'room-limit-exceeded',
+	'room-connection-limit-exceeded',
 ];
 
 /**

--- a/src/constants/sync-errors.ts
+++ b/src/constants/sync-errors.ts
@@ -8,6 +8,7 @@ import type { ConnectionErrorCode } from '@wordpress/sync';
 export const CUSTOM_MODAL_ERROR_CODES: ReadonlyArray< ConnectionErrorCode > = [
 	'collaborator-limit-exceeded',
 	'connection-limit-exceeded',
+	'room-limit-exceeded',
 ];
 
 /**

--- a/src/utilities/room-client-limit.test.ts
+++ b/src/utilities/room-client-limit.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+	isLimitEnforced,
+	isLocalClientWithinLimit,
+	readPresences,
+	COLLABORATOR_INFO_FIELD,
+	type RoomLimitPresence,
+} from './room-client-limit';
+
+function presence( overrides: Partial< RoomLimitPresence > = {} ): RoomLimitPresence {
+	return { clientId: 1, joinedAt: 1000, ...overrides };
+}
+
+describe( 'room-client-limit', () => {
+	describe( 'isLimitEnforced', () => {
+		it( 'treats zero, negatives, and non-finite values as unlimited', () => {
+			assert.strictEqual( isLimitEnforced( 0 ), false );
+			assert.strictEqual( isLimitEnforced( -1 ), false );
+			assert.strictEqual( isLimitEnforced( Number.POSITIVE_INFINITY ), false );
+			assert.strictEqual( isLimitEnforced( Number.NaN ), false );
+		} );
+
+		it( 'enforces positive finite limits', () => {
+			assert.strictEqual( isLimitEnforced( 1 ), true );
+			assert.strictEqual( isLimitEnforced( 300 ), true );
+		} );
+	} );
+
+	describe( 'readPresences', () => {
+		it( 'parses one record per client and skips peers without collaboratorInfo', () => {
+			const states = new Map< number, Record< string, unknown > >( [
+				[ 10, { [ COLLABORATOR_INFO_FIELD ]: { id: 5, enteredAt: 1000 } } ],
+				[ 11, { editorState: { selection: 'no collaboratorInfo yet' } } ],
+				[ 12, { [ COLLABORATOR_INFO_FIELD ]: { enteredAt: 2000 } } ],
+			] );
+
+			assert.deepStrictEqual( readPresences( states ), [
+				{ clientId: 10, joinedAt: 1000 },
+				{ clientId: 12, joinedAt: 2000 },
+			] );
+		} );
+
+		it( 'defaults a missing enteredAt to Infinity so it sorts last', () => {
+			const states = new Map< number, Record< string, unknown > >( [
+				[ 10, { [ COLLABORATOR_INFO_FIELD ]: { id: 5 } } ],
+			] );
+
+			assert.strictEqual( readPresences( states )[ 0 ]?.joinedAt, Number.POSITIVE_INFINITY );
+		} );
+	} );
+
+	describe( 'isLocalClientWithinLimit', () => {
+		it( 'always allows when the limit is not enforced', () => {
+			const presences = [ presence( { clientId: 1, joinedAt: 1 } ) ];
+			assert.strictEqual( isLocalClientWithinLimit( presences, 1, 0 ), true );
+		} );
+
+		it( 'keeps the earliest connections and yields the latest', () => {
+			const presences = [
+				presence( { clientId: 1, joinedAt: 1000 } ),
+				presence( { clientId: 2, joinedAt: 2000 } ),
+				presence( { clientId: 3, joinedAt: 3000 } ),
+			];
+
+			assert.strictEqual( isLocalClientWithinLimit( presences, 1, 2 ), true );
+			assert.strictEqual( isLocalClientWithinLimit( presences, 2, 2 ), true );
+			assert.strictEqual( isLocalClientWithinLimit( presences, 3, 2 ), false );
+		} );
+
+		it( 'breaks join-time ties deterministically by clientId', () => {
+			const presences = [
+				presence( { clientId: 8, joinedAt: 1000 } ),
+				presence( { clientId: 3, joinedAt: 1000 } ),
+			];
+
+			// clientId 3 sorts ahead of 8 at the same joinedAt.
+			assert.strictEqual( isLocalClientWithinLimit( presences, 3, 1 ), true );
+			assert.strictEqual( isLocalClientWithinLimit( presences, 8, 1 ), false );
+		} );
+
+		it( 'counts each connection separately — multiple tabs of one user do NOT dedupe', () => {
+			// All three connections could be the same user in three tabs.
+			const presences = [
+				presence( { clientId: 1, joinedAt: 1000 } ),
+				presence( { clientId: 2, joinedAt: 1500 } ),
+				presence( { clientId: 3, joinedAt: 2000 } ),
+			];
+
+			// With a connection limit of 2, the third tab yields.
+			assert.strictEqual( isLocalClientWithinLimit( presences, 1, 2 ), true );
+			assert.strictEqual( isLocalClientWithinLimit( presences, 2, 2 ), true );
+			assert.strictEqual( isLocalClientWithinLimit( presences, 3, 2 ), false );
+		} );
+
+		it( 'allows the local connection when its presence is not yet visible', () => {
+			const presences = [ presence( { clientId: 1, joinedAt: 1000 } ) ];
+			// Local clientId 99 is not in the awareness set yet.
+			assert.strictEqual( isLocalClientWithinLimit( presences, 99, 1 ), true );
+		} );
+	} );
+} );

--- a/src/utilities/room-client-limit.ts
+++ b/src/utilities/room-client-limit.ts
@@ -1,0 +1,159 @@
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * WordPress hook used to cap the number of concurrent client connections
+ * allowed in a single sync room. Each browser tab is one connection, so this
+ * limits connections, not unique collaborators — a single user with several
+ * tabs counts once per tab. This deliberately reuses the same filter name
+ * exposed by Gutenberg's default (polling) sync provider, which likewise caps
+ * raw client connections per room, so sites that already cap the default
+ * transport keep working after the VIP Real-Time Collaboration plugin swaps in
+ * its WebSocket provider.
+ *
+ * @example
+ * addFilter(
+ *   'sync.pollingProvider.maxClientsPerRoom',
+ *   'my-plugin/cap',
+ *   ( limit, room ) => ( room.includes( 'postType/page-739' ) ? 2 : limit )
+ * );
+ */
+export const MAX_CLIENTS_PER_ROOM_FILTER = 'sync.pollingProvider.maxClientsPerRoom';
+
+/**
+ * Awareness state field Gutenberg already publishes for every client
+ * (see core-data's `BaseAwarenessState.setCurrentCollaboratorInfo`). We read it
+ * rather than writing our own field: Gutenberg's awareness rejects unregistered
+ * fields (`No equality check implemented for awareness state field "…"`), and
+ * `collaboratorInfo` already carries the join time we use to rank connections.
+ */
+export const COLLABORATOR_INFO_FIELD = 'collaboratorInfo';
+
+/**
+ * Sentinel returned when no limit is configured. Treated as "unlimited" so the
+ * default behaviour is unchanged unless a site opts in via the filter.
+ */
+const NO_LIMIT = 0;
+
+export interface RoomLimitPresence {
+	/** The awareness clientID for this connection (unique per browser tab). */
+	clientId: number;
+	/** Wall-clock timestamp (ms) recorded when the connection joined the room. */
+	joinedAt: number;
+}
+
+/**
+ * Resolve the configured per-room client limit for a given room.
+ *
+ * Returns `0` (unlimited) by default; a site enables the cap by returning a
+ * positive integer from the {@link MAX_CLIENTS_PER_ROOM_FILTER} filter.
+ *
+ * @param {string} roomName The sync room name (e.g. `site-1/postType/page-739`).
+ * @return {number} The configured limit, or `0` for unlimited.
+ */
+export function getMaxClientsPerRoom( roomName: string ): number {
+	const limit = applyFilters( MAX_CLIENTS_PER_ROOM_FILTER, NO_LIMIT, roomName );
+	return typeof limit === 'number' ? limit : NO_LIMIT;
+}
+
+/**
+ * Whether a configured limit value actually enforces a cap. Non-positive or
+ * non-finite values mean "unlimited".
+ *
+ * @param {number} limit The configured limit.
+ * @return {boolean} True when the limit should be enforced.
+ */
+export function isLimitEnforced( limit: number ): boolean {
+	return Number.isFinite( limit ) && limit > NO_LIMIT;
+}
+
+/**
+ * Shape of the relevant part of Gutenberg's `collaboratorInfo` awareness field.
+ */
+interface CollaboratorInfo {
+	/** Wall-clock timestamp (ms) Gutenberg stamps when the connection joined. */
+	enteredAt?: number;
+}
+
+/**
+ * Extract one presence record per connected client from a map of awareness
+ * states, reading Gutenberg's own `collaboratorInfo` field for the join time.
+ * Each awareness clientID is a distinct connection (one per tab), so multiple
+ * tabs of the same user yield multiple records — this counts connections.
+ *
+ * Peers that have not yet published `collaboratorInfo` are skipped; they will
+ * appear on a subsequent awareness change once their local state propagates.
+ *
+ * @param {Map<number, Record<string, unknown>>} states Awareness states keyed by clientID.
+ * @return {RoomLimitPresence[]} The parsed presence records.
+ */
+export function readPresences(
+	states: Map< number, Record< string, unknown > >
+): RoomLimitPresence[] {
+	const presences: RoomLimitPresence[] = [];
+
+	for ( const [ clientId, state ] of states ) {
+		const info = state?.[ COLLABORATOR_INFO_FIELD ];
+		if ( ! info || typeof info !== 'object' ) {
+			continue;
+		}
+
+		const { enteredAt } = info as CollaboratorInfo;
+		presences.push( {
+			clientId,
+			joinedAt: typeof enteredAt === 'number' ? enteredAt : Number.POSITIVE_INFINITY,
+		} );
+	}
+
+	return presences;
+}
+
+/**
+ * Order two connections by join time, breaking ties on clientID so every client
+ * computes the same total order without depending on a server.
+ */
+function byJoinOrder( a: RoomLimitPresence, b: RoomLimitPresence ): number {
+	return a.joinedAt - b.joinedAt || a.clientId - b.clientId;
+}
+
+/**
+ * Decide whether the local connection is within the room's client limit.
+ *
+ * Every client runs this same calculation over the shared awareness state and
+ * reaches the same conclusion, so the connections that sort past the limit are
+ * the ones that voluntarily yield. Each connection (browser tab) counts on its
+ * own — there is no per-user dedupe — and connections are ordered by join time
+ * with the clientID as a deterministic tie-breaker, so the newest connections
+ * are the ones that yield.
+ *
+ * Note: this is cooperative, best-effort enforcement. `joinedAt` comes from
+ * each client's own clock, so clock skew can change which connection keeps the
+ * slot when two join close together (the `clientId` tie-break keeps the result
+ * deterministic, not skew-proof). Simultaneous joins can also momentarily
+ * exceed the limit before awareness settles, and it is not a security boundary.
+ * Authoritative ordering and enforcement must live on the server.
+ *
+ * @param {RoomLimitPresence[]} presences     All connections currently in the room (including ours).
+ * @param {number}              localClientId Our own awareness clientID.
+ * @param {number}              limit         The configured per-room connection limit.
+ * @return {boolean} True when the local connection may remain.
+ */
+export function isLocalClientWithinLimit(
+	presences: RoomLimitPresence[],
+	localClientId: number,
+	limit: number
+): boolean {
+	if ( ! isLimitEnforced( limit ) ) {
+		return true;
+	}
+
+	const ordered = [ ...presences ].sort( byJoinOrder );
+	const rank = ordered.findIndex( presence => presence.clientId === localClientId );
+
+	// If we can't find ourselves yet, assume we're within the limit rather than
+	// evicting on incomplete information.
+	if ( rank === -1 ) {
+		return true;
+	}
+
+	return rank < limit;
+}

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -16,6 +16,13 @@ import { generateUUID } from '@/utilities/crypto';
 import { WebSocketError, getErrorMessage } from '@/utilities/error';
 import { memoizeFn } from '@/utilities/function';
 import { Logger } from '@/utilities/logger';
+import {
+	getMaxClientsPerRoom,
+	isLimitEnforced,
+	isLocalClientWithinLimit,
+	readPresences,
+	type RoomLimitPresence,
+} from '@/utilities/room-client-limit';
 import { SyncConnectionStatusEmitter } from '@/utilities/sync-event-emitter';
 
 import type {
@@ -122,6 +129,13 @@ const BACKGROUND_RETRIES_FAILED_THRESHOLD = 3;
  */
 const CONNECTION_STABLE_RESET_DELAY_MS = 2000;
 
+/**
+ * How long to let awareness (presence) settle after a change before deciding
+ * whether the local client is over the room's connection limit. Coalesces
+ * the burst of awareness updates that arrives when peers connect.
+ */
+const ROOM_LIMIT_SETTLE_DELAY_MS = 1500;
+
 interface RetryState {
 	attempts: number;
 }
@@ -183,6 +197,88 @@ function createConnect(
 }
 
 /**
+ * Wire up cooperative, client-side enforcement of the per-room collaborator
+ * limit (see {@link getMaxClientsPerRoom}).
+ *
+ * Every client reads Gutenberg's own `collaboratorInfo` awareness field (user
+ * id + join time) and runs the same deterministic ranking over the shared
+ * awareness state. Clients that sort past the configured limit disconnect
+ * themselves; the existing reconnect loop keeps retrying, so a yielded client
+ * rejoins automatically once a slot frees. We never write to awareness — doing
+ * so would require registering a field equality check with Gutenberg.
+ *
+ * This is best-effort only: simultaneous joins can briefly exceed the limit
+ * before awareness settles, and a modified client can ignore the cap entirely.
+ * Authoritative enforcement must live on the server.
+ *
+ * @param {WebsocketProvider}        provider   The room's provider.
+ * @param {string}                   roomName   The sync room name.
+ * @param {(exceeded: boolean)=>void} onChange  Called with whether the local client is over the limit.
+ * @return {() => void} Cleanup function that detaches listeners.
+ */
+function setupRoomClientLimit(
+	provider: WebsocketProvider,
+	roomName: string,
+	onChange: ( exceeded: boolean ) => void
+): () => void {
+	const limit = getMaxClientsPerRoom( roomName );
+	if ( ! isLimitEnforced( limit ) ) {
+		return () => {};
+	}
+
+	const { awareness } = provider;
+
+	// Ranking uses Gutenberg's `collaboratorInfo.enteredAt`, which is each
+	// client's own wall clock, so first-come-first-served ordering is only as
+	// accurate as the clients' clocks agree. Skew can change who keeps the slot
+	// when two users join close together; the `clientId` tie-break keeps the
+	// ranking deterministic but not skew-proof. This is an accepted tradeoff for
+	// best-effort, client-side enforcement — authoritative ordering would require
+	// the server to stamp join order (see VIP-3150).
+	let settleTimer: ReturnType< typeof setTimeout > | null = null;
+
+	const evaluate = (): void => {
+		settleTimer = null;
+
+		// Only act while connected. On disconnect, awareness collapses to just our
+		// own state and would otherwise read as within the limit.
+		if ( ! provider.wsconnected ) {
+			return;
+		}
+
+		const presences: RoomLimitPresence[] = readPresences(
+			awareness.getStates() as Map< number, Record< string, unknown > >
+		);
+		const withinLimit = isLocalClientWithinLimit( presences, awareness.clientID, limit );
+
+		onChange( ! withinLimit );
+
+		if ( ! withinLimit ) {
+			logger.warn(
+				`Room ${ roomName } is at its connection limit (${ limit }); disconnecting this client.`
+			);
+			provider.disconnect();
+		}
+	};
+
+	const scheduleEvaluate = (): void => {
+		if ( settleTimer !== null ) {
+			clearTimeout( settleTimer );
+		}
+		settleTimer = setTimeout( evaluate, ROOM_LIMIT_SETTLE_DELAY_MS );
+	};
+
+	awareness.on( 'change', scheduleEvaluate );
+
+	return () => {
+		if ( settleTimer !== null ) {
+			clearTimeout( settleTimer );
+		}
+		awareness.off( 'change', scheduleEvaluate );
+	};
+}
+
+/**
  * Function that creates a new WebSocket Connection.
  *
  * @param {string} serverUrl The WebSocket server URL.
@@ -237,13 +333,26 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 			const retryState: RetryState = { attempts: 0 };
 			const connect = createConnect( provider, objectType, objectId ?? 'collection', retryState );
 
+			// Set when this connection voluntarily yields its slot because the room
+			// is over its configured connection limit (see `setupRoomClientLimit`).
+			// This yield is terminal: the close handler surfaces the limit modal and
+			// does NOT reconnect. Reconnecting would re-occupy the slot, re-trigger
+			// the eviction, and thrash the server (manifesting as a follow-on 4002
+			// connection-limit rejection).
+			let roomLimitExceeded = false;
+
 			// Create a typed event emitter for our custom sync-connection-status event.
 			const syncStatusEmitter = new SyncConnectionStatusEmitter();
+
+			const cleanupRoomClientLimit = setupRoomClientLimit( provider, roomName, exceeded => {
+				roomLimitExceeded = exceeded;
+			} );
 
 			const handleConnectionClose = ( event: CloseEvent | null ): void => {
 				const closeCode = event?.code;
 				const isCustomModalError =
-					closeCode !== undefined && CUSTOM_MODAL_CLOSE_CODES.has( closeCode );
+					roomLimitExceeded ||
+					( closeCode !== undefined && CUSTOM_MODAL_CLOSE_CODES.has( closeCode ) );
 
 				// Retry-state fields drive Gutenberg's default modal (countdown
 				// and threshold-based reveal). Omit them for errors handled by
@@ -262,11 +371,16 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 
 				syncStatusEmitter.emit( {
 					status: 'disconnected',
-					error: getErrorFromCloseCode( closeCode ),
+					error: roomLimitExceeded
+						? new WebSocketError( 'collaborator-limit-exceeded' )
+						: getErrorFromCloseCode( closeCode ),
 					...retryStateFields,
 				} );
 
-				void connect();
+				// A room-limit yield is terminal — do not reconnect (see above).
+				if ( ! roomLimitExceeded ) {
+					void connect();
+				}
 			};
 
 			provider.on( 'connection-close', handleConnectionClose );
@@ -326,6 +440,7 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 
 			return {
 				destroy: () => {
+					cleanupRoomClientLimit();
 					syncStatusEmitter.destroy();
 					provider.destroy();
 				},

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -385,7 +385,7 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 				syncStatusEmitter.emit( {
 					status: 'disconnected',
 					error: roomLimitExceeded
-						? new WebSocketError( 'room-limit-exceeded' )
+						? new WebSocketError( 'room-connection-limit-exceeded' )
 						: getErrorFromCloseCode( closeCode ),
 					...retryStateFields,
 				} );

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -200,12 +200,13 @@ function createConnect(
  * Wire up cooperative, client-side enforcement of the per-room collaborator
  * limit (see {@link getMaxClientsPerRoom}).
  *
- * Every client reads Gutenberg's own `collaboratorInfo` awareness field (user
- * id + join time) and runs the same deterministic ranking over the shared
- * awareness state. Clients that sort past the configured limit disconnect
- * themselves; the existing reconnect loop keeps retrying, so a yielded client
- * rejoins automatically once a slot frees. We never write to awareness — doing
- * so would require registering a field equality check with Gutenberg.
+ * Every client reads Gutenberg's own `collaboratorInfo` awareness field for
+ * each connection's join time and runs the same deterministic ranking over the
+ * shared awareness state. Connections that sort past the configured limit
+ * disconnect themselves; the yield is terminal (the close handler does not
+ * reconnect), so a yielded user must reload to retry. We never write to
+ * awareness — doing so would require registering a field equality check with
+ * Gutenberg.
  *
  * This is best-effort only: simultaneous joins can briefly exceed the limit
  * before awareness settles, and a modified client can ignore the cap entirely.
@@ -268,13 +269,25 @@ function setupRoomClientLimit(
 		settleTimer = setTimeout( evaluate, ROOM_LIMIT_SETTLE_DELAY_MS );
 	};
 
+	// Re-evaluate whenever the socket (re)connects, not only on awareness change.
+	// Awareness state may already be present, or have arrived before the socket
+	// finished opening, in which case `evaluate` would otherwise have bailed on
+	// `! provider.wsconnected` with nothing left to re-trigger it.
+	const onStatus = ( event: { status?: string } ): void => {
+		if ( event?.status === 'connected' ) {
+			scheduleEvaluate();
+		}
+	};
+
 	awareness.on( 'change', scheduleEvaluate );
+	provider.on( 'status', onStatus );
 
 	return () => {
 		if ( settleTimer !== null ) {
 			clearTimeout( settleTimer );
 		}
 		awareness.off( 'change', scheduleEvaluate );
+		provider.off( 'status', onStatus );
 	};
 }
 
@@ -372,7 +385,7 @@ export function createWebSocketConnection( serverUrl: string ): ProviderCreator 
 				syncStatusEmitter.emit( {
 					status: 'disconnected',
 					error: roomLimitExceeded
-						? new WebSocketError( 'collaborator-limit-exceeded' )
+						? new WebSocketError( 'room-limit-exceeded' )
 						: getErrorFromCloseCode( closeCode ),
 					...retryStateFields,
 				} );

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -13,6 +13,7 @@ declare module '@wordpress/sync' {
 		| 'collaborator-limit-exceeded'
 		| 'connection-expired'
 		| 'connection-limit-exceeded'
+		| 'room-limit-exceeded'
 		| 'unknown-error';
 
 	interface ConnectionError extends Error {

--- a/types/wordpress__sync/index.d.ts
+++ b/types/wordpress__sync/index.d.ts
@@ -13,7 +13,7 @@ declare module '@wordpress/sync' {
 		| 'collaborator-limit-exceeded'
 		| 'connection-expired'
 		| 'connection-limit-exceeded'
-		| 'room-limit-exceeded'
+		| 'room-connection-limit-exceeded'
 		| 'unknown-error';
 
 	interface ConnectionError extends Error {


### PR DESCRIPTION
## Summary

Adds an optional, client-side cap on the number of concurrent **connections** (browser tabs/clients) to a single sync room, honoring the `sync.pollingProvider.maxClientsPerRoom` filter — the same hook Gutenberg's default polling transport exposes — so sites that already cap the default transport keep working after the VIP WebSocket provider takes over.

## Behavior

- **No-op unless opted in.** `setupRoomClientLimit` bails immediately when `getMaxClientsPerRoom` returns a non-positive / non-finite value (the default with no filter). With no enforcing filter, the connect / reconnect / modal flow is byte-for-byte identical to `trunk` — only an extra side-effect-free `applyFilters` call per room runs.
- **When enforced**, each client ranks the room's connections by join time (read from Gutenberg's own `collaboratorInfo.enteredAt`, `clientId` tie-break) and the **newest** connections past the cap disconnect themselves. Counting is **per connection (per tab)**, not per unique user — matching the filter name and Gutenberg's own `checkConnectionLimit` semantics.
- The yield is **terminal**: it surfaces a dedicated `room-limit-exceeded` modal and does **not** reconnect, avoiding a reconnect/evict thrash that would otherwise trip the server's connection limit (observed as a follow-on `4002`).

## Implementation notes

- Reads Gutenberg's existing `collaboratorInfo` awareness field rather than writing a custom field (Gutenberg's `AwarenessWithEqualityChecks` throws on unregistered fields).
- Dedicated `room-limit-exceeded` error code + modal copy (not reused from the server-side collaborator/connection limits, whose "we'll keep trying" copy is wrong for this terminal path).
- Re-evaluates on every `connected` status, not only on awareness changes, so an over-limit client is caught even when awareness was already present before the socket opened.

## Scope / safety

This is **best-effort, cooperative** enforcement (simultaneous joins can briefly exceed the cap; a modified client can ignore it). Authoritative per-room limits must live on the server — tracked in **VIP-3150**.

## Testing

- Unit tests for the ranking/parsing helpers (`room-client-limit.test.ts`).
- Manually verified in `wp-env` with a throwaway mu-plugin capping post 2: latecomer/extra-tab yields with the modal, established clients keep editing, no reconnect thrash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)