### PR TITLE
Fix offline and auth connection error reporting

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -126,27 +126,19 @@ function getBackoffDelayInMs( attempts: number ): number {
 	return Math.min( 1000 * 2 ** attempts, WEBSOCKET_PROVIDER_MAX_BACKOFF_IN_MS );
 }
 
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return typeof value === 'object' && value !== null;
+}
+
 /**
  * Map WordPress REST authorization responses from the token endpoint to the
  * sync error code that Gutenberg uses for its authentication message. Network
  * and other request failures do not have a trustworthy authorization status.
  */
 function getTokenFetchErrorCode( error: unknown ): ConnectionError[ 'code' ] {
-	if ( ! error || typeof error !== 'object' || ! ( 'data' in error ) ) {
-		return 'unknown-error';
-	}
+	const status = isRecord( error ) && isRecord( error.data ) ? error.data.status : undefined;
 
-	const { data } = error;
-	if (
-		data &&
-		typeof data === 'object' &&
-		'status' in data &&
-		( data.status === 401 || data.status === 403 )
-	) {
-		return 'authentication-failed';
-	}
-
-	return 'unknown-error';
+	return status === 401 || status === 403 ? 'authentication-failed' : 'unknown-error';
 }
 
 /**

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -28,6 +28,7 @@ import { SyncConnectionStatusEmitter } from '@/utilities/sync-event-emitter';
 import { getWebSocketClosePolicy, getWebSocketCloseScope } from '@/websocket-close-policy';
 
 import type {
+	ConnectionError,
 	ConnectionStatus,
 	ProviderCreator,
 	ProviderCreatorOptions,
@@ -126,6 +127,29 @@ function getBackoffDelayInMs( attempts: number ): number {
 }
 
 /**
+ * Map WordPress REST authorization responses from the token endpoint to the
+ * sync error code that Gutenberg uses for its authentication message. Network
+ * and other request failures do not have a trustworthy authorization status.
+ */
+function getTokenFetchErrorCode( error: unknown ): ConnectionError[ 'code' ] {
+	if ( ! error || typeof error !== 'object' || ! ( 'data' in error ) ) {
+		return 'unknown-error';
+	}
+
+	const { data } = error;
+	if (
+		data &&
+		typeof data === 'object' &&
+		'status' in data &&
+		( data.status === 401 || data.status === 403 )
+	) {
+		return 'authentication-failed';
+	}
+
+	return 'unknown-error';
+}
+
+/**
  * Configure the websocket provider to use auth token for websocket connection.
  * Implement exponential backoff for reconnect attempts since we are opting out
  * of the built-in reconnect logic by disabling `provider.shouldConnect`.
@@ -137,6 +161,7 @@ function createConnect(
 	retryState: { attempts: number; eligible: boolean },
 	fetchToken: ( syncObjectType: string, syncObjectId: string ) => Promise< string >,
 	waitBeforeRetry: ( delayInMs: number ) => Promise< void >,
+	onRetryableTokenFetchFailure: ( errorCode: ConnectionError[ 'code' ] ) => void,
 	onFatalConnectError: ( error: unknown ) => void
 ): () => Promise< void > {
 	let hasAttemptedConnect = false;
@@ -171,6 +196,8 @@ function createConnect(
 				) }: ${ getErrorMessage( error ) }`
 			);
 			if ( retryState.eligible ) {
+				// Token fetch failures do not trigger y-websocket's connection-close event.
+				onRetryableTokenFetchFailure( getTokenFetchErrorCode( error ) );
 				// Keep the initial provider creation detached from a REST outage.
 				void connect().catch( () => {} );
 			}
@@ -382,6 +409,18 @@ export function createWebSocketConnection(
 
 			// Create a typed event emitter for our custom sync-connection-status event.
 			const syncStatusEmitter = new SyncConnectionStatusEmitter();
+			const getRetryStatusFields = () => ( {
+				willAutoRetryInMs: getBackoffDelayInMs( retryState.attempts ),
+				backgroundRetriesFailed: retryState.attempts >= BACKGROUND_RETRIES_FAILED_THRESHOLD,
+			} );
+			const handleRetryableTokenFetchFailure = ( errorCode: ConnectionError[ 'code' ] ): void => {
+				const syncStatus = {
+					status: 'disconnected' as const,
+					error: new WebSocketError( errorCode ),
+					...getRetryStatusFields(),
+				};
+				syncStatusEmitter.emit( syncStatus );
+			};
 
 			const cleanupRoomClientLimit = setupRoomClientLimit( provider, roomName, exceeded => {
 				roomLimitExceeded = exceeded;
@@ -418,12 +457,7 @@ export function createWebSocketConnection(
 				// the takeover check. `canManuallyRetry` is never set: the
 				// default modal's Retry button calls `retrySyncConnection()`
 				// which only reaches the built-in HTTP polling provider.
-				const retryStateFields = closePolicy.includeRetryMetadata
-					? {
-							willAutoRetryInMs: getBackoffDelayInMs( retryState.attempts ),
-							backgroundRetriesFailed: retryState.attempts >= BACKGROUND_RETRIES_FAILED_THRESHOLD,
-					  }
-					: {};
+				const retryStateFields = closePolicy.includeRetryMetadata ? getRetryStatusFields() : {};
 
 				syncStatusEmitter.emit( {
 					status: 'disconnected',
@@ -489,6 +523,7 @@ export function createWebSocketConnection(
 				retryState,
 				fetchToken,
 				waitBeforeRetry,
+				handleRetryableTokenFetchFailure,
 				error => {
 					logger.critical( 'Fatal WebSocket connection failure', { error } );
 					disposeProvider();

--- a/src/websocket/websocket-client.test.ts
+++ b/src/websocket/websocket-client.test.ts
@@ -194,6 +194,7 @@ describe( 'createWebSocketConnection multiplex lifecycle', () => {
 
 		const retryingStatus = lastStatus( context.statuses );
 		assert.strictEqual( retryingStatus.status, 'disconnected' );
+		assert.strictEqual( retryingStatus.error?.code, 'unknown-error' );
 		assert.strictEqual( retryingStatus.willAutoRetryInMs, 4000 );
 		assert.strictEqual( retryingStatus.backgroundRetriesFailed, false );
 
@@ -210,11 +211,16 @@ describe( 'createWebSocketConnection multiplex lifecycle', () => {
 		destroyProvider( context );
 	} );
 
-	for ( const statusCode of [ 401, 403 ] ) {
-		it( `reports a token ${ statusCode } failure with the authentication error code`, async () => {
+	for ( const [ description, errorData, expectedErrorCode ] of [
+		[ '401 response', { status: 401 }, 'authentication-failed' ],
+		[ '403 response', { status: 403 }, 'authentication-failed' ],
+		[ '500 response', { status: 500 }, 'unknown-error' ],
+		[ 'malformed response', 'invalid-data', 'unknown-error' ],
+	] as const ) {
+		it( `maps a token ${ description } to ${ expectedErrorCode }`, async () => {
 			let finishBackoff = (): void => {};
 			const authorizationError = Object.assign( new Error( 'Authorization failed' ), {
-				data: { status: statusCode },
+				data: errorData,
 			} );
 			const providerCreator = createWebSocketConnection( 'wss://example.test/_ws/', {
 				multiplexingEnabled: true,
@@ -233,7 +239,7 @@ describe( 'createWebSocketConnection multiplex lifecycle', () => {
 
 			const status = lastStatus( context.statuses );
 			assert.strictEqual( status.status, 'disconnected' );
-			assert.strictEqual( status.error?.code, 'authentication-failed' );
+			assert.strictEqual( status.error?.code, expectedErrorCode );
 			assert.strictEqual( status.backgroundRetriesFailed, false );
 			destroyProvider( context );
 		} );

--- a/src/websocket/websocket-client.test.ts
+++ b/src/websocket/websocket-client.test.ts
@@ -173,6 +173,72 @@ describe( 'createWebSocketConnection multiplex lifecycle', () => {
 		destroyProvider( context );
 	} );
 
+	it( 'surfaces repeated token-fetch failures as disconnected after background retries fail', async () => {
+		const finishBackoffs: Array< () => void > = [];
+		const providerCreator = createWebSocketConnection( 'wss://example.test/_ws/', {
+			multiplexingEnabled: true,
+			PhysicalWebSocket: FakePhysicalWebSocket as unknown as typeof WebSocket,
+			fetchToken: () => Promise.reject( new Error( 'offline' ) ),
+			waitBeforeRetry: () =>
+				new Promise( resolve => {
+					finishBackoffs.push( resolve );
+				} ),
+		} );
+
+		const context = await createProviderFromCreator( providerCreator, '123' );
+		const firstBackoff = finishBackoffs[ 0 ];
+		assert.ok( firstBackoff );
+		firstBackoff();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const retryingStatus = lastStatus( context.statuses );
+		assert.strictEqual( retryingStatus.status, 'disconnected' );
+		assert.strictEqual( retryingStatus.willAutoRetryInMs, 4000 );
+		assert.strictEqual( retryingStatus.backgroundRetriesFailed, false );
+
+		const secondBackoff = finishBackoffs[ 1 ];
+		assert.ok( secondBackoff );
+		secondBackoff();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const exhaustedStatus = lastStatus( context.statuses );
+		assert.strictEqual( exhaustedStatus.status, 'disconnected' );
+		assert.strictEqual( exhaustedStatus.willAutoRetryInMs, 8000 );
+		assert.strictEqual( exhaustedStatus.backgroundRetriesFailed, true );
+		destroyProvider( context );
+	} );
+
+	for ( const statusCode of [ 401, 403 ] ) {
+		it( `reports a token ${ statusCode } failure with the authentication error code`, async () => {
+			let finishBackoff = (): void => {};
+			const authorizationError = Object.assign( new Error( 'Authorization failed' ), {
+				data: { status: statusCode },
+			} );
+			const providerCreator = createWebSocketConnection( 'wss://example.test/_ws/', {
+				multiplexingEnabled: true,
+				PhysicalWebSocket: FakePhysicalWebSocket as unknown as typeof WebSocket,
+				fetchToken: () => Promise.reject( authorizationError ),
+				waitBeforeRetry: () =>
+					new Promise( resolve => {
+						finishBackoff = resolve;
+					} ),
+			} );
+
+			const context = await createProviderFromCreator( providerCreator, '123' );
+			finishBackoff();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			const status = lastStatus( context.statuses );
+			assert.strictEqual( status.status, 'disconnected' );
+			assert.strictEqual( status.error?.code, 'authentication-failed' );
+			assert.strictEqual( status.backgroundRetriesFailed, false );
+			destroyProvider( context );
+		} );
+	}
+
 	it( 'does not reconnect after teardown during an in-flight token request', async () => {
 		let resolveToken = ( _grant: string ): void => {};
 		const inFlightToken = new Promise< string >( resolve => {


### PR DESCRIPTION
### Description

- Surface token-fetch failures through the RTC sync status emitter so Gutenberg can show its disconnected modal after background retries are exhausted.
- Classify token endpoint `401` and `403` responses as `authentication-failed`, allowing Gutenberg to show its permission-specific message.
- Keep network and other token-fetch failures as `unknown-error`.
- Reuse the same retry metadata for token-fetch failures and WebSocket-close failures.
- Add coverage for offline retry exhaustion and both `401`/`403` token failures.

### Testing

1. Run `npm run dev`
2. Spin up two browser sessions
3. Simulate offline mode in one of em
4. Ensure the modal shows up
5. Force 401 and 403 to be returned from the auth endpoint for the two different browser sessions
6. Ensure the modal shows up with the auth failed text

<img width="653" height="303" alt="CleanShot 2026-08-07 at 11 43 55" src="https://github.com/user-attachments/assets/8fb3cc49-ed2e-4edd-883a-242807e23dc4" />

<img width="652" height="302" alt="CleanShot 2026-08-07 at 11 42 51" src="https://github.com/user-attachments/assets/46cddf5f-d142-45a5-aa0c-8f60f45c924f" />
