### PR TITLE
Use explicit multiplex WebSocket paths

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,7 +4,7 @@
     "VIP_RTC_WS_AUTH_SECRET": "vip_rtc_ws_auth_secret",
     "VIP_RTC_WS_AUTH_TOKEN_EXPIRE_SECONDS": 3600,
     "VIP_RTC_WS_MULTIPLEXING_ENABLED": true,
-    "VIP_RTC_WS_URL": "ws://localhost:1234",
+    "VIP_RTC_WS_URL": "ws://localhost:1234/_ws",
     "WP_DEBUG_DISPLAY": true,
     "WP_DEVELOPMENT_MODE": "plugin",
     "WP_ENVIRONMENT_TYPE": "development"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,12 +42,12 @@ This starts WordPress at `http://localhost:8888` and the local WebSocket server 
 
 The following PHP constants are automatically defined in our development environment:
 
-| Variable                               | Value                    | Description                                  |
-| -------------------------------------- | ------------------------ | -------------------------------------------- |
-| `VIP_RTC_WS_URL`                       | `ws://localhost:1234`    | WebSocket URL for Yjs sync provider          |
-| `VIP_RTC_WS_AUTH_SECRET`               | `vip_rtc_ws_auth_secret` | Secret used to generate auth tokens          |
-| `VIP_RTC_WS_AUTH_TOKEN_EXPIRE_SECONDS` | `3600`                   | Auth token expiration in seconds             |
-| `VIP_RTC_WS_MULTIPLEXING_ENABLED`      | `true`                   | Share one multiplexed WebSocket across rooms |
+| Variable                               | Value                     | Description                                  |
+| -------------------------------------- | ------------------------- | -------------------------------------------- |
+| `VIP_RTC_WS_URL`                       | `ws://localhost:1234/_ws` | WebSocket URL for Yjs sync provider          |
+| `VIP_RTC_WS_AUTH_SECRET`               | `vip_rtc_ws_auth_secret`  | Secret used to generate auth tokens          |
+| `VIP_RTC_WS_AUTH_TOKEN_EXPIRE_SECONDS` | `3600`                    | Auth token expiration in seconds             |
+| `VIP_RTC_WS_MULTIPLEXING_ENABLED`      | `true`                    | Share one multiplexed WebSocket across rooms |
 
 If you use a different development environment, ensure these variables are set accordingly. Note that `VIP_RTC_WS_AUTH_SECRET` must also be provided as an environment variable to the WebSocket server.
 

--- a/src/shared-websocket.ts
+++ b/src/shared-websocket.ts
@@ -184,7 +184,7 @@ export function createSharedWebSocketAdapter(
 
 	function openPhysicalSocket( grant: string ): void {
 		const socket = new PhysicalWebSocket(
-			`${ normalizedServerUrl }?auth=${ encodeURIComponent( grant ) }`,
+			`${ normalizedServerUrl }/multiplex?auth=${ encodeURIComponent( grant ) }`,
 			MULTIPLEX_SUBPROTOCOL
 		);
 		physicalSocket = socket;

--- a/src/shared-websocket.ts
+++ b/src/shared-websocket.ts
@@ -184,7 +184,7 @@ export function createSharedWebSocketAdapter(
 
 	function openPhysicalSocket( grant: string ): void {
 		const socket = new PhysicalWebSocket(
-			`${ normalizedServerUrl }/multiplex?auth=${ encodeURIComponent( grant ) }`,
+			`${ normalizedServerUrl }/vip-rtc?auth=${ encodeURIComponent( grant ) }`,
 			MULTIPLEX_SUBPROTOCOL
 		);
 		physicalSocket = socket;

--- a/src/websocket/shared-websocket.test.ts
+++ b/src/websocket/shared-websocket.test.ts
@@ -37,7 +37,7 @@ describe( 'createSharedWebSocketAdapter', () => {
 
 		const physical = FakePhysicalWebSocket.instances[ 0 ];
 		assert.ok( physical );
-		assert.strictEqual( physical.url, 'wss://example.test/_ws/multiplex?auth=grant-1' );
+		assert.strictEqual( physical.url, 'wss://example.test/_ws/vip-rtc?auth=grant-1' );
 		assert.strictEqual( physical.protocols, 'vip-rtc-multiplex-v1' );
 		assert.strictEqual( physical.binaryType, 'arraybuffer' );
 
@@ -58,7 +58,7 @@ describe( 'createSharedWebSocketAdapter', () => {
 		assert.strictEqual( FakePhysicalWebSocket.instances.length, 1 );
 	} );
 
-	it( 'opens the explicit multiplex path for a direct server URL', () => {
+	it( 'opens the explicit VIP RTC path for a direct server URL', () => {
 		const SharedWebSocket = createSharedWebSocketAdapter(
 			'ws://localhost:1234/',
 			FakePhysicalWebSocket as unknown as typeof WebSocket
@@ -67,7 +67,7 @@ describe( 'createSharedWebSocketAdapter', () => {
 
 		const physical = FakePhysicalWebSocket.instances[ 0 ];
 		assert.ok( physical );
-		assert.strictEqual( physical.url, 'ws://localhost:1234/multiplex?auth=grant-1' );
+		assert.strictEqual( physical.url, 'ws://localhost:1234/vip-rtc?auth=grant-1' );
 	} );
 
 	it( 'rejects missing or empty rooms and auth grants', () => {

--- a/src/websocket/shared-websocket.test.ts
+++ b/src/websocket/shared-websocket.test.ts
@@ -58,18 +58,6 @@ describe( 'createSharedWebSocketAdapter', () => {
 		assert.strictEqual( FakePhysicalWebSocket.instances.length, 1 );
 	} );
 
-	it( 'opens the explicit VIP RTC path for a direct server URL', () => {
-		const SharedWebSocket = createSharedWebSocketAdapter(
-			'ws://localhost:1234/',
-			FakePhysicalWebSocket as unknown as typeof WebSocket
-		);
-		new SharedWebSocket( 'ws://localhost:1234/site-7/postType/page-123?auth=grant-1' );
-
-		const physical = FakePhysicalWebSocket.instances[ 0 ];
-		assert.ok( physical );
-		assert.strictEqual( physical.url, 'ws://localhost:1234/vip-rtc?auth=grant-1' );
-	} );
-
 	it( 'rejects missing or empty rooms and auth grants', () => {
 		const SharedWebSocket = createSharedWebSocketAdapter(
 			'wss://example.test/_ws/',

--- a/src/websocket/shared-websocket.test.ts
+++ b/src/websocket/shared-websocket.test.ts
@@ -16,7 +16,7 @@ describe( 'createSharedWebSocketAdapter', () => {
 		FakePhysicalWebSocket.instances = [];
 	} );
 
-	it( 'normalizes room URLs into one neutral multiplex socket and rejects lookalike bases', () => {
+	it( 'normalizes room URLs into one multiplex socket and rejects lookalike bases', () => {
 		const SharedWebSocket = createSharedWebSocketAdapter(
 			'wss://example.test/_ws/',
 			FakePhysicalWebSocket as unknown as typeof WebSocket
@@ -37,7 +37,7 @@ describe( 'createSharedWebSocketAdapter', () => {
 
 		const physical = FakePhysicalWebSocket.instances[ 0 ];
 		assert.ok( physical );
-		assert.strictEqual( physical.url, 'wss://example.test/_ws?auth=grant-1' );
+		assert.strictEqual( physical.url, 'wss://example.test/_ws/multiplex?auth=grant-1' );
 		assert.strictEqual( physical.protocols, 'vip-rtc-multiplex-v1' );
 		assert.strictEqual( physical.binaryType, 'arraybuffer' );
 
@@ -56,6 +56,18 @@ describe( 'createSharedWebSocketAdapter', () => {
 			/normalized server URL/
 		);
 		assert.strictEqual( FakePhysicalWebSocket.instances.length, 1 );
+	} );
+
+	it( 'opens the explicit multiplex path for a direct server URL', () => {
+		const SharedWebSocket = createSharedWebSocketAdapter(
+			'ws://localhost:1234/',
+			FakePhysicalWebSocket as unknown as typeof WebSocket
+		);
+		new SharedWebSocket( 'ws://localhost:1234/site-7/postType/page-123?auth=grant-1' );
+
+		const physical = FakePhysicalWebSocket.instances[ 0 ];
+		assert.ok( physical );
+		assert.strictEqual( physical.url, 'ws://localhost:1234/multiplex?auth=grant-1' );
 	} );
 
 	it( 'rejects missing or empty rooms and auth grants', () => {

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -31,7 +31,7 @@ require_once "{$_tests_dir}/includes/functions.php";
 require_once __DIR__ . '/../../vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
 // Define WebSocket constants for testing.
-define( 'VIP_RTC_WS_URL', 'ws://localhost:1234' );
+define( 'VIP_RTC_WS_URL', 'ws://localhost:1234/_ws' );
 define( 'VIP_RTC_WS_AUTH_SECRET', 'vip_rtc_ws_auth_secret' );
 
 // Manually load the plugin being tested.

--- a/tests/e2e/specs/multiplexed-rtc.spec.ts
+++ b/tests/e2e/specs/multiplexed-rtc.spec.ts
@@ -162,7 +162,7 @@ function recordMultiplexTransport( page: Page, wsUrl: string ): TransportRecorde
 		}
 	};
 	page.on( 'websocket', socket => {
-		if ( ! socket.url().startsWith( `${ wsUrl }/multiplex?auth=` ) ) {
+		if ( ! socket.url().startsWith( `${ wsUrl }/vip-rtc?auth=` ) ) {
 			return;
 		}
 		recorder.createdSocketCount += 1;
@@ -313,7 +313,7 @@ test.describe( 'multiplexed RTC transport', () => {
 		try {
 			// Phase: a multiplex upgrade owns no room until its explicit subscribe.
 			const rawSocket = new NodeWebSocket(
-				`${ wsUrl }/multiplex?auth=${ encodeURIComponent( primaryGrant ) }`,
+				`${ wsUrl }/vip-rtc?auth=${ encodeURIComponent( primaryGrant ) }`,
 				MULTIPLEX_SUBPROTOCOL
 			);
 			cleanups.push( () => rawSocket.close() );

--- a/tests/e2e/specs/multiplexed-rtc.spec.ts
+++ b/tests/e2e/specs/multiplexed-rtc.spec.ts
@@ -18,7 +18,7 @@ import {
 	type ProtocolMessage,
 } from '../../../websocket-server/protocol';
 
-const WEBSOCKET_URL = process.env.WS_URL ?? 'ws://localhost:1234';
+const WEBSOCKET_URL = process.env.WS_URL ?? 'ws://localhost:1234/_ws';
 const EXTENDED_POLL_TIMEOUT_MS = 15_000;
 
 interface AuthResponse {

--- a/tests/e2e/specs/multiplexed-rtc.spec.ts
+++ b/tests/e2e/specs/multiplexed-rtc.spec.ts
@@ -162,7 +162,7 @@ function recordMultiplexTransport( page: Page, wsUrl: string ): TransportRecorde
 		}
 	};
 	page.on( 'websocket', socket => {
-		if ( ! socket.url().startsWith( `${ wsUrl }/?auth=` ) ) {
+		if ( ! socket.url().startsWith( `${ wsUrl }/multiplex?auth=` ) ) {
 			return;
 		}
 		recorder.createdSocketCount += 1;
@@ -311,9 +311,9 @@ test.describe( 'multiplexed RTC transport', () => {
 		const cleanups: Array< () => void > = [];
 
 		try {
-			// Phase: a neutral upgrade owns no room until its explicit subscribe.
+			// Phase: a multiplex upgrade owns no room until its explicit subscribe.
 			const rawSocket = new NodeWebSocket(
-				`${ wsUrl }/?auth=${ encodeURIComponent( primaryGrant ) }`,
+				`${ wsUrl }/multiplex?auth=${ encodeURIComponent( primaryGrant ) }`,
 				MULTIPLEX_SUBPROTOCOL
 			);
 			cleanups.push( () => rawSocket.close() );

--- a/websocket-server/server.test.ts
+++ b/websocket-server/server.test.ts
@@ -206,8 +206,8 @@ describe( 'WebSocket transport routing', () => {
 	} );
 
 	for ( const [ path, protocols ] of [
-		[ '/multiplex', [ MULTIPLEX_SUBPROTOCOL ] ],
-		[ '/_ws/multiplex', [ 'vip-rtc-multiplex-v2', MULTIPLEX_SUBPROTOCOL ] ],
+		[ '/vip-rtc', [ MULTIPLEX_SUBPROTOCOL ] ],
+		[ '/_ws/vip-rtc', [ 'vip-rtc-multiplex-v2', MULTIPLEX_SUBPROTOCOL ] ],
 	] as const ) {
 		it( `routes ${ path } through multiplex and selects V1 from ${ protocols.join(
 			', '
@@ -335,7 +335,7 @@ describe( 'WebSocket transport routing', () => {
 		{ timeout: 1_000 },
 		async () => {
 			const baseUrl = await startServer();
-			const path = `/multiplex?auth=${ grant( 'site-7/post-invalid-frame' ) }`;
+			const path = `/vip-rtc?auth=${ grant( 'site-7/post-invalid-frame' ) }`;
 			const client = await connect( baseUrl, path, MULTIPLEX_SUBPROTOCOL );
 			const closed = once( client, 'close' );
 
@@ -405,7 +405,7 @@ describe( 'WebSocket transport routing', () => {
 		await connect( baseUrl, `/_ws/${ room }?auth=${ grant( room ) }` );
 		const multiplex = await connect(
 			baseUrl,
-			`/multiplex?auth=${ grant( room ) }`,
+			`/vip-rtc?auth=${ grant( room ) }`,
 			MULTIPLEX_SUBPROTOCOL
 		);
 		const subscribed = waitForMultiplexMessage(
@@ -428,7 +428,7 @@ describe( 'WebSocket transport routing', () => {
 			const laterRoom = 'site-7/post-later';
 			const client = await connect(
 				baseUrl,
-				`/multiplex?auth=${ grant( initialRoom ) }`,
+				`/vip-rtc?auth=${ grant( initialRoom ) }`,
 				MULTIPLEX_SUBPROTOCOL
 			);
 			const subscribed = waitForMultiplexMessage(
@@ -475,7 +475,7 @@ describe( 'WebSocket transport routing', () => {
 		const bootstrapGrant = grant( room, { exp: 1_700_000_001 } );
 		const client = await connect(
 			baseUrl,
-			`/multiplex?auth=${ bootstrapGrant }`,
+			`/vip-rtc?auth=${ bootstrapGrant }`,
 			MULTIPLEX_SUBPROTOCOL
 		);
 
@@ -504,7 +504,7 @@ describe( 'WebSocket transport routing', () => {
 			const messagesBefore = await metricValue( 'wpvip_rtc_messages_total' );
 			const baseUrl = await startServer( 100 );
 			const room = `site-7/post-common-${ protocol ? 'multiplex' : 'legacy' }`;
-			const path = protocol ? '/multiplex' : `/${ room }`;
+			const path = protocol ? '/vip-rtc' : `/${ room }`;
 			const client = await connect( baseUrl, `${ path }?auth=${ grant( room ) }`, protocol );
 			const closePromise = once( client, 'close' );
 

--- a/websocket-server/server.test.ts
+++ b/websocket-server/server.test.ts
@@ -206,10 +206,10 @@ describe( 'WebSocket transport routing', () => {
 	} );
 
 	for ( const [ path, protocols ] of [
-		[ '/', [ MULTIPLEX_SUBPROTOCOL ] ],
-		[ '/_ws', [ 'vip-rtc-multiplex-v2', MULTIPLEX_SUBPROTOCOL ] ],
+		[ '/multiplex', [ MULTIPLEX_SUBPROTOCOL ] ],
+		[ '/_ws/multiplex', [ 'vip-rtc-multiplex-v2', MULTIPLEX_SUBPROTOCOL ] ],
 	] as const ) {
-		it( `routes neutral ${ path } through multiplex and selects V1 from ${ protocols.join(
+		it( `routes ${ path } through multiplex and selects V1 from ${ protocols.join(
 			', '
 		) }`, async () => {
 			const activeRoomsBefore = await metricValue( 'wpvip_rtc_active_room_connections' );
@@ -252,23 +252,25 @@ describe( 'WebSocket transport routing', () => {
 		} );
 	}
 
-	it( 'rejects a room-specific path selected for multiplex transport', async () => {
-		const baseUrl = await startServer();
-		const room = 'site-7/post-room-path';
-		const client = new WebSocket( `${ baseUrl }/${ room }?auth=${ grant( room ) }`, [
-			MULTIPLEX_SUBPROTOCOL,
-		] );
-		clients.add( client );
+	for ( const path of [ '/', '/_ws', '/site-7/post-room-path' ] ) {
+		it( `rejects ${ path } selected for multiplex transport`, async () => {
+			const baseUrl = await startServer();
+			const room = 'site-7/post-room-path';
+			const client = new WebSocket( `${ baseUrl }${ path }?auth=${ grant( room ) }`, [
+				MULTIPLEX_SUBPROTOCOL,
+			] );
+			clients.add( client );
 
-		const result = await upgradeResult( client );
+			const result = await upgradeResult( client );
 
-		assert.strictEqual( result.type, 'error' );
-		assert.match(
-			result.type === 'error' ? result.error.message : '',
-			/Unexpected server response: 400/
-		);
-		assert.strictEqual( docs.has( room ), false );
-	} );
+			assert.strictEqual( result.type, 'error' );
+			assert.match(
+				result.type === 'error' ? result.error.message : '',
+				/Unexpected server response: 400/
+			);
+			assert.strictEqual( docs.has( room ), false );
+		} );
+	}
 
 	it( 'rejects unsupported-only subprotocols without falling back to legacy', async () => {
 		const baseUrl = await startServer();
@@ -333,7 +335,7 @@ describe( 'WebSocket transport routing', () => {
 		{ timeout: 1_000 },
 		async () => {
 			const baseUrl = await startServer();
-			const path = `/?auth=${ grant( 'site-7/post-invalid-frame' ) }`;
+			const path = `/multiplex?auth=${ grant( 'site-7/post-invalid-frame' ) }`;
 			const client = await connect( baseUrl, path, MULTIPLEX_SUBPROTOCOL );
 			const closed = once( client, 'close' );
 
@@ -401,7 +403,11 @@ describe( 'WebSocket transport routing', () => {
 		const baseUrl = await startServer();
 		const room = 'site-7/post-shared';
 		await connect( baseUrl, `/_ws/${ room }?auth=${ grant( room ) }` );
-		const multiplex = await connect( baseUrl, `/?auth=${ grant( room ) }`, MULTIPLEX_SUBPROTOCOL );
+		const multiplex = await connect(
+			baseUrl,
+			`/multiplex?auth=${ grant( room ) }`,
+			MULTIPLEX_SUBPROTOCOL
+		);
 		const subscribed = waitForMultiplexMessage(
 			multiplex,
 			message => message.type === 'subscribed' && message.room === room
@@ -422,7 +428,7 @@ describe( 'WebSocket transport routing', () => {
 			const laterRoom = 'site-7/post-later';
 			const client = await connect(
 				baseUrl,
-				`/?auth=${ grant( initialRoom ) }`,
+				`/multiplex?auth=${ grant( initialRoom ) }`,
 				MULTIPLEX_SUBPROTOCOL
 			);
 			const subscribed = waitForMultiplexMessage(
@@ -467,7 +473,11 @@ describe( 'WebSocket transport routing', () => {
 		const baseUrl = await startServer();
 		const room = 'site-7/post-expired-bootstrap';
 		const bootstrapGrant = grant( room, { exp: 1_700_000_001 } );
-		const client = await connect( baseUrl, `/?auth=${ bootstrapGrant }`, MULTIPLEX_SUBPROTOCOL );
+		const client = await connect(
+			baseUrl,
+			`/multiplex?auth=${ bootstrapGrant }`,
+			MULTIPLEX_SUBPROTOCOL
+		);
 
 		t.mock.timers.setTime( 1_700_000_002_000 );
 		const roomClosed = waitForMultiplexMessage(
@@ -494,7 +504,7 @@ describe( 'WebSocket transport routing', () => {
 			const messagesBefore = await metricValue( 'wpvip_rtc_messages_total' );
 			const baseUrl = await startServer( 100 );
 			const room = `site-7/post-common-${ protocol ? 'multiplex' : 'legacy' }`;
-			const path = protocol ? '/' : `/${ room }`;
+			const path = protocol ? '/multiplex' : `/${ room }`;
 			const client = await connect( baseUrl, `${ path }?auth=${ grant( room ) }`, protocol );
 			const closePromise = once( client, 'close' );
 

--- a/websocket-server/server.test.ts
+++ b/websocket-server/server.test.ts
@@ -205,54 +205,48 @@ describe( 'WebSocket transport routing', () => {
 		assert.strictEqual( docs.get( room )?.conns.size, 1 );
 	} );
 
-	for ( const [ path, protocols ] of [
-		[ '/vip-rtc', [ MULTIPLEX_SUBPROTOCOL ] ],
-		[ '/_ws/vip-rtc', [ 'vip-rtc-multiplex-v2', MULTIPLEX_SUBPROTOCOL ] ],
-	] as const ) {
-		it( `routes ${ path } through multiplex and selects V1 from ${ protocols.join(
-			', '
-		) }`, async () => {
-			const activeRoomsBefore = await metricValue( 'wpvip_rtc_active_room_connections' );
-			const baseUrl = await startServer();
-			const room = `site-7/post-${ protocols.length }`;
-			const bootstrapGrant = grant( room );
-			let selectedHeader: string | undefined;
-			const client = new WebSocket( `${ baseUrl }${ path }?auth=${ bootstrapGrant }`, [
-				...protocols,
-			] );
-			clients.add( client );
-			client.on( 'upgrade', response => {
-				selectedHeader = response.headers[ 'sec-websocket-protocol' ];
-			} );
-			await once( client, 'open' );
-
-			assert.strictEqual( client.protocol, MULTIPLEX_SUBPROTOCOL );
-			assert.strictEqual( selectedHeader, MULTIPLEX_SUBPROTOCOL );
-			assert.strictEqual( docs.has( room ), false );
-			assert.strictEqual( runningServer?.wss.clients.size, 1 );
-			assert.strictEqual(
-				await metricValue( 'wpvip_rtc_active_room_connections' ),
-				activeRoomsBefore
-			);
-
-			const messages: ProtocolMessage[] = [];
-			const roomReady = new Promise< void >( resolve => {
-				client.on( 'message', data => {
-					messages.push( decodeMessage( data as Uint8Array ) );
-					if ( messages.length === 2 ) {
-						resolve();
-					}
-				} );
-			} );
-			client.send( encodeMessage( { type: 'subscribe', room, grant: bootstrapGrant } ) );
-			await roomReady;
-			assert.deepStrictEqual( messages[ 0 ], { type: 'subscribed', room } );
-			assert.strictEqual( messages[ 1 ]?.type, 'data' );
-			assert.strictEqual( messages[ 1 ]?.room, room );
+	it( 'routes /_ws/vip-rtc through multiplex and selects V1', async () => {
+		const activeRoomsBefore = await metricValue( 'wpvip_rtc_active_room_connections' );
+		const baseUrl = await startServer();
+		const room = 'site-7/post-multiplex';
+		const bootstrapGrant = grant( room );
+		let selectedHeader: string | undefined;
+		const client = new WebSocket( `${ baseUrl }/_ws/vip-rtc?auth=${ bootstrapGrant }`, [
+			'vip-rtc-multiplex-v2',
+			MULTIPLEX_SUBPROTOCOL,
+		] );
+		clients.add( client );
+		client.on( 'upgrade', response => {
+			selectedHeader = response.headers[ 'sec-websocket-protocol' ];
 		} );
-	}
+		await once( client, 'open' );
 
-	for ( const path of [ '/', '/_ws', '/site-7/post-room-path' ] ) {
+		assert.strictEqual( client.protocol, MULTIPLEX_SUBPROTOCOL );
+		assert.strictEqual( selectedHeader, MULTIPLEX_SUBPROTOCOL );
+		assert.strictEqual( docs.has( room ), false );
+		assert.strictEqual( runningServer?.wss.clients.size, 1 );
+		assert.strictEqual(
+			await metricValue( 'wpvip_rtc_active_room_connections' ),
+			activeRoomsBefore
+		);
+
+		const messages: ProtocolMessage[] = [];
+		const roomReady = new Promise< void >( resolve => {
+			client.on( 'message', data => {
+				messages.push( decodeMessage( data as Uint8Array ) );
+				if ( messages.length === 2 ) {
+					resolve();
+				}
+			} );
+		} );
+		client.send( encodeMessage( { type: 'subscribe', room, grant: bootstrapGrant } ) );
+		await roomReady;
+		assert.deepStrictEqual( messages[ 0 ], { type: 'subscribed', room } );
+		assert.strictEqual( messages[ 1 ]?.type, 'data' );
+		assert.strictEqual( messages[ 1 ]?.room, room );
+	} );
+
+	for ( const path of [ '/', '/_ws', '/vip-rtc', '/site-7/post-room-path' ] ) {
 		it( `rejects ${ path } selected for multiplex transport`, async () => {
 			const baseUrl = await startServer();
 			const room = 'site-7/post-room-path';
@@ -335,7 +329,7 @@ describe( 'WebSocket transport routing', () => {
 		{ timeout: 1_000 },
 		async () => {
 			const baseUrl = await startServer();
-			const path = `/vip-rtc?auth=${ grant( 'site-7/post-invalid-frame' ) }`;
+			const path = `/_ws/vip-rtc?auth=${ grant( 'site-7/post-invalid-frame' ) }`;
 			const client = await connect( baseUrl, path, MULTIPLEX_SUBPROTOCOL );
 			const closed = once( client, 'close' );
 
@@ -405,7 +399,7 @@ describe( 'WebSocket transport routing', () => {
 		await connect( baseUrl, `/_ws/${ room }?auth=${ grant( room ) }` );
 		const multiplex = await connect(
 			baseUrl,
-			`/vip-rtc?auth=${ grant( room ) }`,
+			`/_ws/vip-rtc?auth=${ grant( room ) }`,
 			MULTIPLEX_SUBPROTOCOL
 		);
 		const subscribed = waitForMultiplexMessage(
@@ -428,7 +422,7 @@ describe( 'WebSocket transport routing', () => {
 			const laterRoom = 'site-7/post-later';
 			const client = await connect(
 				baseUrl,
-				`/vip-rtc?auth=${ grant( initialRoom ) }`,
+				`/_ws/vip-rtc?auth=${ grant( initialRoom ) }`,
 				MULTIPLEX_SUBPROTOCOL
 			);
 			const subscribed = waitForMultiplexMessage(
@@ -475,7 +469,7 @@ describe( 'WebSocket transport routing', () => {
 		const bootstrapGrant = grant( room, { exp: 1_700_000_001 } );
 		const client = await connect(
 			baseUrl,
-			`/vip-rtc?auth=${ bootstrapGrant }`,
+			`/_ws/vip-rtc?auth=${ bootstrapGrant }`,
 			MULTIPLEX_SUBPROTOCOL
 		);
 
@@ -504,7 +498,7 @@ describe( 'WebSocket transport routing', () => {
 			const messagesBefore = await metricValue( 'wpvip_rtc_messages_total' );
 			const baseUrl = await startServer( 100 );
 			const room = `site-7/post-common-${ protocol ? 'multiplex' : 'legacy' }`;
-			const path = protocol ? '/vip-rtc' : `/${ room }`;
+			const path = protocol ? '/_ws/vip-rtc' : `/${ room }`;
 			const client = await connect( baseUrl, `${ path }?auth=${ grant( room ) }`, protocol );
 			const closePromise = once( client, 'close' );
 

--- a/websocket-server/server.ts
+++ b/websocket-server/server.ts
@@ -85,7 +85,7 @@ export function createRtcServer( options: RtcServerOptions ): RtcServer {
 		const initialGrant = authResult.grant;
 		const pathname = getRequestPathname( request );
 		if ( isMultiplex ) {
-			if ( pathname !== '/' && pathname !== '/_ws' ) {
+			if ( ! [ '/multiplex', '/_ws/multiplex' ].includes( pathname ) ) {
 				recordConnectionFailure( 'invalid_multiplex_path' );
 				rejectHttpUpgrade( socket, '400 Bad Request' );
 				return;

--- a/websocket-server/server.ts
+++ b/websocket-server/server.ts
@@ -85,7 +85,7 @@ export function createRtcServer( options: RtcServerOptions ): RtcServer {
 		const initialGrant = authResult.grant;
 		const pathname = getRequestPathname( request );
 		if ( isMultiplex ) {
-			if ( ! [ '/multiplex', '/_ws/multiplex' ].includes( pathname ) ) {
+			if ( ! [ '/vip-rtc', '/_ws/vip-rtc' ].includes( pathname ) ) {
 				recordConnectionFailure( 'invalid_multiplex_path' );
 				rejectHttpUpgrade( socket, '400 Bad Request' );
 				return;

--- a/websocket-server/server.ts
+++ b/websocket-server/server.ts
@@ -85,7 +85,7 @@ export function createRtcServer( options: RtcServerOptions ): RtcServer {
 		const initialGrant = authResult.grant;
 		const pathname = getRequestPathname( request );
 		if ( isMultiplex ) {
-			if ( ! [ '/vip-rtc', '/_ws/vip-rtc' ].includes( pathname ) ) {
+			if ( pathname !== '/_ws/vip-rtc' ) {
 				recordConnectionFailure( 'invalid_multiplex_path' );
 				rejectHttpUpgrade( socket, '400 Bad Request' );
 				return;


### PR DESCRIPTION
## Description

Multiplex connections currently use the base WebSocket URL, which can fail in environments that require an explicit WebSocket path. This PR moves those connections to a dedicated `/vip-rtc` endpoint and updates both the server and client. The service-level name avoids tying the URL to the multiplex implementation and can remain stable if multiplexing becomes the default transport. Direct `/vip-rtc` and prefixed `/_ws/vip-rtc` URLs are both supported.

## Testing

1. Run the local development environment:

   ```sh
   npm run dev
   ```

2. Open the same post in two separate browser sessions and sign in as different users.
3. Make edits from both sessions and confirm normal collaboration works, including synced changes and collaborator presence.
4. In browser DevTools, open **Network → WS** and confirm the shared connection uses `ws://localhost:1234/vip-rtc?auth=...`.
