### PR TITLE
Use .nvmrc in release workflows

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Configure Git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.version_check.outputs.new_version
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Build plugin zip


### PR DESCRIPTION
## Description

The release PR and release workflows currently pin Node 24, while the rest of the project uses Node 22 through `.nvmrc`. This mismatch caused the generated [v0.4.0 release PR (#213)](https://github.com/Automattic/vip-real-time-collaboration/pull/213) to initially include unrelated `package-lock.json` changes that needed a follow-up commit to restore the Node 22 entries.

This PR updates both workflows to read the Node version from the root `.nvmrc` ([docs](https://github.com/actions/setup-node/blob/v4/docs/advanced-usage.md#node-version-file)), keeping release automation aligned with the rest of the project and avoiding similar lockfile churn in future release PRs.
