### PR TITLE
Use Y shim instead of wp.sync bundle

### DIFF
--- a/inc/Assets/Assets.php
+++ b/inc/Assets/Assets.php
@@ -15,6 +15,7 @@ use function wp_add_inline_script;
 use function wp_create_nonce;
 use function wp_die;
 use function wp_enqueue_script;
+use function wp_script_is;
 
 /**
  * Enqueues the necessary JavaScript and CSS assets for the plugin.
@@ -54,7 +55,16 @@ final class Assets {
 		 */
 		$asset = include $asset_file;
 
-		$dependencies = array_unique( array_merge( $asset['dependencies'], [ 'wp-sync' ] ) );
+		$dependencies = $asset['dependencies'];
+
+		// Gutenberg versions before WordPress/gutenberg#81999 expose the editor's
+		// Yjs instance on the `wp.sync` global, which our bundle reads at load
+		// time. Newer versions no longer register the `wp-sync` script handle and
+		// pass Yjs to the provider creator instead, so only depend on the handle
+		// when it exists. An unregistered dependency would block the enqueue.
+		if ( wp_script_is( 'wp-sync', 'registered' ) ) {
+			$dependencies = array_unique( array_merge( $dependencies, [ 'wp-sync' ] ) );
+		}
 
 		wp_enqueue_script(
 			'vip-real-time-collaboration',

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -1,7 +1,8 @@
 import type {
 	ConnectionStatus as WordPressConnectionStatus,
-	ProviderCreatorOptions,
+	ProviderCreatorOptions as WordPressProviderCreatorOptions,
 } from '@wordpress/sync';
+import type * as YjsModule from 'yjs';
 
 type ConnectedStatus = Exclude< WordPressConnectionStatus, { status: 'disconnected' } >;
 type DisconnectedStatus = Extract< WordPressConnectionStatus, { status: 'disconnected' } >;
@@ -45,8 +46,17 @@ export interface ProviderCreatorResult {
 	on: ProviderOn;
 }
 
+/**
+ * WordPress's provider creator options widened with the `Y` option added in
+ * WordPress/gutenberg#81999. Newer Gutenberg versions pass the editor's Yjs
+ * module here. Older versions expose it as the `wp.sync.Y` global instead, so
+ * the option stays optional. This local widening can be removed once the
+ * installed `@wordpress/sync` types include `Y`.
+ */
+export type ProviderCreatorOptions = WordPressProviderCreatorOptions & {
+	Y?: typeof YjsModule;
+};
+
 export type ProviderCreator = (
 	options: ProviderCreatorOptions
 ) => Promise< ProviderCreatorResult >;
-
-export type { ProviderCreatorOptions };

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -26,6 +26,7 @@ import {
 } from '@/utilities/room-client-limit';
 import { SyncConnectionStatusEmitter } from '@/utilities/sync-event-emitter';
 import { getWebSocketClosePolicy, getWebSocketCloseScope } from '@/websocket-close-policy';
+import { setYjsModule } from '@/yjs-shim';
 
 import type {
 	ConnectionStatus,
@@ -340,8 +341,15 @@ export function createWebSocketConnection(
 		objectType,
 		objectId,
 		ydoc,
+		Y,
 	}: ProviderCreatorOptions ): Promise< ProviderCreatorResult > {
 		try {
+			if ( Y ) {
+				// Point the bundled y-websocket and y-protocols modules at the
+				// Yjs instance used by the editor. See yjs-shim.ts.
+				setYjsModule( Y );
+			}
+
 			// For now, we only support collections and traditional post types.
 			const isUnsupportedObjectType =
 				null !== objectId &&

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -26,7 +26,7 @@ import {
 } from '@/utilities/room-client-limit';
 import { SyncConnectionStatusEmitter } from '@/utilities/sync-event-emitter';
 import { getWebSocketClosePolicy, getWebSocketCloseScope } from '@/websocket-close-policy';
-import { setYjsModule } from '@/yjs-shim';
+import { isYjsModuleSet, setYjsModule } from '@/yjs-shim';
 
 import type {
 	ConnectionStatus,
@@ -348,6 +348,15 @@ export function createWebSocketConnection(
 				// Point the bundled y-websocket and y-protocols modules at the
 				// Yjs instance used by the editor. See yjs-shim.ts.
 				setYjsModule( Y );
+			} else if ( ! isYjsModuleSet() ) {
+				// Without a Yjs module, the bundled y-websocket and y-protocols
+				// modules would fail later with an obscure TypeError when the
+				// first sync message is written. Fail fast with a clear message.
+				logger.error(
+					'WebSocket sync disabled: no Yjs module available. Expected the `Y` provider option or the `wp.sync.Y` global (older Gutenberg).'
+				);
+
+				return defaultResult;
 			}
 
 			// For now, we only support collections and traditional post types.

--- a/src/websocket/missing-yjs-module.test.ts
+++ b/src/websocket/missing-yjs-module.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert';
+import { afterEach, describe, it, mock } from 'node:test';
+import { Awareness } from 'y-protocols/awareness';
+import * as Yjs from 'yjs';
+
+import { createWebSocketConnection } from '../websocket-client';
+import { FakePhysicalWebSocket } from './fake-physical-websocket.test-helper';
+
+/**
+ * These tests run in their own file so the yjs-shim module state starts
+ * unfilled: the test runner starts one process per test file, and the other
+ * websocket tests fill the shim by passing the `Y` provider option.
+ */
+describe( 'createWebSocketConnection without a Yjs module', () => {
+	afterEach( () => {
+		FakePhysicalWebSocket.instances = [];
+		mock.restoreAll();
+	} );
+
+	it( 'logs a clear error and returns an inert provider when Y is missing', async () => {
+		const logged: unknown[][] = [];
+		mock.method( console, 'log', ( ...args: unknown[] ) => {
+			logged.push( args );
+		} );
+
+		let authFetchCount = 0;
+		const providerCreator = createWebSocketConnection( 'wss://example.test/_ws/', {
+			multiplexingEnabled: true,
+			PhysicalWebSocket: FakePhysicalWebSocket as unknown as typeof WebSocket,
+			fetchToken: () => {
+				authFetchCount += 1;
+				return Promise.resolve( `grant-${ authFetchCount }` );
+			},
+		} );
+
+		const doc = new Yjs.Doc();
+		const awareness = new Awareness( doc );
+
+		const result = await providerCreator( {
+			awareness,
+			objectType: 'postType/page',
+			objectId: '123',
+			ydoc: doc,
+		} );
+
+		const errorLogs = logged.filter( args =>
+			args.some( arg => 'string' === typeof arg && arg.includes( 'no Yjs module available' ) )
+		);
+		assert.strictEqual( errorLogs.length, 1 );
+
+		// The creator must bail out before doing any connection work.
+		assert.strictEqual( FakePhysicalWebSocket.instances.length, 0 );
+		assert.strictEqual( authFetchCount, 0 );
+
+		// The inert result must still be safe to use.
+		result.on( 'status', () => {} );
+		result.destroy();
+
+		// Destroy the awareness interval and doc so the test process can exit.
+		awareness.destroy();
+		doc.destroy();
+	} );
+} );

--- a/src/websocket/websocket-client.test.ts
+++ b/src/websocket/websocket-client.test.ts
@@ -66,6 +66,7 @@ async function createProviderFromCreator(
 		objectType: 'postType/page',
 		objectId,
 		ydoc: doc,
+		Y: Yjs,
 	} );
 	const statuses: ConnectionStatus[] = [];
 	result.on( 'status', status => statuses.push( status ) );

--- a/src/yjs-shim.ts
+++ b/src/yjs-shim.ts
@@ -29,8 +29,21 @@ export let applyUpdate: typeof YjsModule.applyUpdate;
 export let encodeStateAsUpdate: typeof YjsModule.encodeStateAsUpdate;
 export let encodeStateVector: typeof YjsModule.encodeStateVector;
 
+let yjsModuleSet = false;
+
 export function setYjsModule( Y: typeof YjsModule ): void {
 	( { Doc, applyUpdate, encodeStateAsUpdate, encodeStateVector } = Y );
+	yjsModuleSet = true;
+}
+
+/**
+ * Whether a Yjs module has been loaded into the shim, from either the `Y`
+ * provider option or the legacy `wp.sync.Y` global. When this is false, any
+ * Yjs call made by the bundled y-websocket and y-protocols modules would
+ * throw, so callers should treat it as a fatal configuration error.
+ */
+export function isYjsModuleSet(): boolean {
+	return yjsModuleSet;
 }
 
 // Unit tests run in Node, where `window` is undefined.

--- a/src/yjs-shim.ts
+++ b/src/yjs-shim.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared-Yjs shim for the bundled y-websocket and y-protocols modules.
+ *
+ * The webpack build aliases the `yjs` module specifier to this file, so the
+ * bundled y-websocket and y-protocols modules resolve Yjs symbols here
+ * instead of bundling their own copy. Two Yjs instances operating on the same
+ * document cause silent data corruption:
+ *
+ * https://github.com/yjs/yjs/issues/438
+ *
+ * The editor's Yjs instance arrives in one of two ways:
+ *
+ * - Newer Gutenberg versions pass it to the provider creator as the `Y`
+ *   option (see WordPress/gutenberg#81999). The provider creator calls
+ *   `setYjsModule()` before constructing the WebSocket provider.
+ * - Older Gutenberg versions expose it as the `wp.sync.Y` global, which this
+ *   module reads at load time.
+ *
+ * Only the symbols actually referenced by y-websocket and y-protocols need
+ * to be re-exported here. The exports are live bindings: y-websocket and
+ * y-protocols only dereference them inside functions that run after the
+ * provider creator has been called, so filling them in at that point is
+ * early enough.
+ */
+import type * as YjsModule from 'yjs';
+
+export let Doc: typeof YjsModule.Doc;
+export let applyUpdate: typeof YjsModule.applyUpdate;
+export let encodeStateAsUpdate: typeof YjsModule.encodeStateAsUpdate;
+export let encodeStateVector: typeof YjsModule.encodeStateVector;
+
+export function setYjsModule( Y: typeof YjsModule ): void {
+	( { Doc, applyUpdate, encodeStateAsUpdate, encodeStateVector } = Y );
+}
+
+// Unit tests run in Node, where `window` is undefined.
+const legacyY = typeof window !== 'undefined' ? window.wp?.sync?.Y : undefined;
+
+if ( legacyY ) {
+	setYjsModule( legacyY );
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,8 +2,11 @@ declare global {
 	interface Window {
 		VIP_RTC: VIPRTCConfig;
 
-		wp: {
-			sync: {
+		// Gutenberg versions before WordPress/gutenberg#81999 expose the
+		// editor's Yjs instance on the `wp.sync` global. Newer versions no
+		// longer register it and pass Yjs to the provider creator instead.
+		wp?: {
+			sync?: {
 				Y: typeof import('yjs');
 			};
 		};

--- a/webpack.utils.js
+++ b/webpack.utils.js
@@ -14,19 +14,6 @@ function modernize( config, additionalScripts = {}, additionalPlugins = [], watc
 			...config.entry(),
 			...additionalScripts,
 		},
-		externals: {
-			...config.externals,
-			// Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
-			'@wordpress/sync': 'wp.sync',
-
-			// Resolve Yjs to the global `wp.sync.Y` provided by the sync package.
-			// Since dependencies import 'yjs' directly, we need to avoid importing
-			// and packaging two different Yjs instances, which would result in this
-			// conflict:
-			//
-			// https://github.com/yjs/yjs/issues/438
-			yjs: 'wp.sync.Y',
-		},
 		module: {
 			rules: config.module.rules.concat( [
 				{
@@ -48,6 +35,14 @@ function modernize( config, additionalScripts = {}, additionalPlugins = [], watc
 			alias: {
 				...config.resolve.alias,
 				'@': path.resolve( __dirname, 'src/' ),
+
+				// Resolve the bare `yjs` specifier to a shim that shares the
+				// editor's Yjs instance. y-websocket and y-protocols import
+				// 'yjs' directly; bundling a second Yjs copy would cause this
+				// conflict:
+				//
+				// https://github.com/yjs/yjs/issues/438
+				yjs$: path.resolve( __dirname, 'src/yjs-shim.ts' ),
 			},
 		},
 		watchOptions: { ...config.watchOptions, ...watchOptions },


### PR DESCRIPTION
Gutenberg is removing `wp.sync` and will instead pass the editor's Yjs module to sync providers as a `Y` option in https://github.com/WordPress/gutenberg/pull/81999. This PR updates the WebSocket transport to consume the new option. It stays backwards-compatible with Gutenberg versions that still expose `wp.sync.Y`.

## How the shim avoids a second Yjs instance

Our bundle includes `y-websocket` and `y-protocols`, which statically import `yjs`. If webpack resolved that import normally, the plugin would ship its own copy of Yjs alongside the editor's copy, and two Yjs instances working on the same document silently corrupt data (see [yjs#438](https://github.com/yjs/yjs/issues/438)).

Instead, the build now aliases the `yjs` module name to `src/yjs-shim.ts`, so those libraries load the shim instead of bundling a second Yjs. The shim re-exports the functions the libraries actually use, initially with no value. Because module exports are live bindings, the libraries read the current value at call time rather than at load time, and they only call Yjs functions after a provider is constructed. That makes it safe to fill in the shim when the provider creator runs. An inert initial Yjs import exists, but is replaced with the working singular Gutenberg `Y` export before any code is actually run.

## Testing

I updated `.wp-env.json`'s Gutenberg plugin to point to a local copy of https://github.com/WordPress/gutenberg/pull/81999, with WordPress 7.1 (which doesn't already import `wp.sync`):

```js
{
  /* ... */
  "core": "WordPress/WordPress#7.1",
  "plugins": [ ".", "/Users/alec/<path-to-gutenberg-pr-checkout>" ]
}
```

Additionally, run the WebSockets server in a terminal:

```bash
$ VIP_RTC_WS_AUTH_SECRET=vip_rtc_ws_auth_secret npm run dev:websocket-server
```

After everything is running, test RTC works without a `wp.sync` global:

https://github.com/user-attachments/assets/c68da4b4-5f07-4117-9948-39d885d746c7