### PR TITLE
Prevent fatal errors from non-array setting arguments

### DIFF
--- a/inc/Settings/Settings.php
+++ b/inc/Settings/Settings.php
@@ -57,15 +57,15 @@ final class Settings {
 	 * Remove RTC from Gutenberg's experiments schema so this plugin is the only
 	 * place where the feature can be enabled or disabled.
 	 *
-	 * @param array<string, mixed> $args The setting registration arguments.
+	 * @param mixed                $args The setting registration arguments.
 	 * @param array<string, mixed> $_defaults The default registration arguments.
 	 * @param string               $option_group The setting group.
 	 * @param string               $option_name The setting name.
-	 * @return array<string, mixed> The filtered registration arguments.
+	 * @return mixed The filtered registration arguments.
 	 * @psalm-suppress PossiblyUnusedReturnValue Psalm does not detect usage via add_filter.
 	 */
-	public static function hide_gutenberg_rtc_experiment( array $args, array $_defaults, string $option_group, string $option_name ): array {
-		if ( self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_group || self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_name ) {
+	public static function hide_gutenberg_rtc_experiment( mixed $args, array $_defaults, string $option_group, string $option_name ): mixed {
+		if ( self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_group || self::GUTENBERG_EXPERIMENTS_OPTION_NAME !== $option_name || ! is_array( $args ) ) {
 			return $args;
 		}
 

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -174,6 +174,20 @@ final class SettingsTest extends TestCase {
 	}
 
 	/**
+	 * Verifies that non-array arguments for unrelated settings are unchanged.
+	 *
+	 * @covers \VIPRealTimeCollaboration\Settings\Settings::hide_gutenberg_rtc_experiment
+	 */
+	public function test_unrelated_setting_with_string_args_is_unchanged(): void {
+		$args = 'legacy-setting-args';
+
+		self::assertSame(
+			$args,
+			apply_filters( 'register_setting_args', $args, [], 'another-group', 'another-option' )
+		);
+	}
+
+	/**
 	 * Verifies that enabling RTC preserves other Gutenberg experiments.
 	 *
 	 * @covers \VIPRealTimeCollaboration\Settings\Settings::set_gutenberg_rtc_experiment


### PR DESCRIPTION
## Description

  Fixes a fatal TypeError in `Settings::hide_gutenberg_rtc_experiment()` when another WordPress setting passes a string through the global `register_setting_args` filter.

  The callback now accepts mixed arguments and returns non-array values unchanged. Array arguments continue through the existing logic that removes the RTC experiment from Gutenberg’s settings schema.

  A regression test covers string arguments passed through the actual WordPress filter.

 ## Manual testing

  1. Start the local WordPress environment:

     npm run wp-env -- start

  2. Trigger the problematic hook with string setting arguments:

     npm run wp-cli -- eval "register_setting( 'test-group', 'test-option', 'legacy-setting-args' ); echo 'Registration completed.';"

  3. Confirm the command prints Registration completed. without a TypeError.
  4. Sign in to WordPress Admin and open Settings → VIP Real-Time Collaboration.
  5. Confirm the settings page loads without errors and the RTC enabled/disabled setting can still be saved.
  6. Run the focused automated test:

     npm run test:integration -- --filter SettingsTest

  7. Confirm all Settings integration tests pass.